### PR TITLE
add compressed support to image_rect 

### DIFF
--- a/pylon_camera/include/pylon_camera/pylon_camera_node.h
+++ b/pylon_camera/include/pylon_camera/pylon_camera_node.h
@@ -986,7 +986,7 @@ protected:
     image_transport::ImageTransport* it_;
     image_transport::CameraPublisher img_raw_pub_;
 
-    ros::Publisher* img_rect_pub_;
+    image_transport::Publisher* img_rect_pub_;
     image_geometry::PinholeCameraModel* pinhole_model_;
 
     GrabImagesAS grab_imgs_raw_as_;

--- a/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
@@ -557,8 +557,7 @@ void PylonCameraNode::setupRectification()
 {
     if ( !img_rect_pub_ )
     {
-        img_rect_pub_ = new ros::Publisher(
-                            nh_.advertise<sensor_msgs::Image>("image_rect", 1));
+        img_rect_pub_ = new image_transport::Publisher(it_->advertise("image_rect", 1));
     }
 
     if ( !grab_imgs_rect_as_ )
@@ -675,7 +674,7 @@ void PylonCameraNode::spin()
                     img_raw_msg_.encoding);
             pinhole_model_->fromCameraInfo(camera_info_manager_->getCameraInfo());
             pinhole_model_->rectifyImage(cv_img_raw->image, cv_bridge_img_rect_->image);
-            img_rect_pub_->publish(*cv_bridge_img_rect_);
+            img_rect_pub_->publish(cv_bridge_img_rect_->toImageMsg());
         }
     }
     // Check if the image encoding changed , then save the new image encoding and restart the image grabbing to fix the ros sensor message type issue.


### PR DESCRIPTION
The publisher of `image_rect` was of type  `ros::Publisher*` I changed type to `image_transport::Publisher*`. 
If you have installed ROS-Package [compressed_image_transport](http://wiki.ros.org/compressed_image_transport) every publisher of type `image_transport::Publisher` also provides `compressed`images. 
Whyever the publisher of ìmage_raw` already had the right type. 