### PR TITLE
Fix Ace2 USB Camera startup error NODE NOT WRITABLE

### DIFF
--- a/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -625,6 +625,8 @@ std::string PylonCameraImpl<CameraTraitT>::setImageEncoding(const std::string& r
         if ( GenApi::IsAvailable(cam_->PixelFormat) )
         {
             GenApi::INodeMap& node_map = cam_->GetNodeMap();
+            cam_->StartGrabbing();
+            cam_->StopGrabbing();
             GenApi::CEnumerationPtr(node_map.GetNode("PixelFormat"))->FromString(gen_api_encoding.c_str());
             return "done";
         }


### PR DESCRIPTION
Fix the error in setting the image encoding & other parameters at startup of Ace 2 USB Cameras.