### PR TITLE
Hardware Trigger Support

### DIFF
--- a/pylon_camera/include/pylon_camera/internal/impl/HardwareTriggerConfiguration.h
+++ b/pylon_camera/include/pylon_camera/internal/impl/HardwareTriggerConfiguration.h
@@ -1,0 +1,146 @@
+//-----------------------------------------------------------------------------
+//  Basler pylon SDK
+//  Copyright (c) 2010-2020 Basler AG
+//  http://www.baslerweb.com
+//  Author:  M.Binev
+//           N.Bhatt (University of Waterloo)
+//-----------------------------------------------------------------------------
+/*!
+\file
+\brief An instant camera configuration for hardware trigger.
+       This  instant camera configuration is provided as header-only file. The code
+       can be copied and modified for creating own configuration classes.
+*/
+
+
+#include <pylon/Platform.h>
+
+#ifdef _MSC_VER
+#   pragma pack(push, PYLON_PACKING)
+#endif /* _MSC_VER */
+
+#include <pylon/InstantCamera.h>
+#include <pylon/ParameterIncludes.h>
+// #include <pylon/ConfigurationHelper.h> // Uncomment for Basler Ace 2
+
+namespace Pylon
+{
+    /** \addtogroup Pylon_InstantCameraApiGeneric
+     * @{
+     */
+
+    /*!
+    \class  CHardwareTriggerConfiguration
+    \brief  Changes the configuration of the camera so that the acquisition of frames is triggered by hardware trigger.
+    */
+    class CHardwareTriggerConfiguration : public CConfigurationEventHandler
+    {
+    public:
+        /// Apply hardware trigger configuration.
+        static void ApplyConfiguration( GENAPI_NAMESPACE::INodeMap& nodemap)
+        {
+            using namespace GENAPI_NAMESPACE;
+
+            //Disable compression mode.
+            // CConfigurationHelper::DisableCompression( nodemap ); // Uncomment for Basler Ace 2
+
+            // Disable all trigger types except the trigger type used for triggering the acquisition of
+            // frames.
+            {
+                // Get required enumerations.
+                CEnumParameter triggerSelector(nodemap, "TriggerSelector");
+                CEnumParameter triggerMode(nodemap, "TriggerMode");
+
+                // Check the available camera trigger mode(s) to select the appropriate one: acquisition start trigger mode
+                // (used by older cameras, i.e. for cameras supporting only the legacy image acquisition control mode;
+                // do not confuse with acquisition start command) or frame start trigger mode
+                // (used by newer cameras, i.e. for cameras using the standard image acquisition control mode;
+                // equivalent to the acquisition start trigger mode in the legacy image acquisition control mode).
+                String_t triggerName("FrameStart");
+                if (!triggerSelector.CanSetValue(triggerName))
+                {
+                    triggerName = "AcquisitionStart";
+                    if (!triggerSelector.CanSetValue(triggerName))
+                    {
+                        throw RUNTIME_EXCEPTION("Could not select trigger. Neither FrameStart nor AcquisitionStart is available.");
+                    }
+                }
+
+                // Get all enumeration entries of trigger selector.
+                StringList_t triggerSelectorEntries;
+                triggerSelector.GetSettableValues(triggerSelectorEntries);
+
+                // Turn trigger mode off for all trigger selector entries except for the frame trigger given by triggerName.
+                for (StringList_t::const_iterator it = triggerSelectorEntries.begin(); it != triggerSelectorEntries.end(); ++it)
+                {
+                    // Set trigger mode to off.
+                    triggerSelector.SetValue(*it);
+                    if (triggerName == *it)
+                    {
+                        // Activate trigger.
+                        triggerMode.SetValue("On");
+
+                        // Enable the following line to use software trigger instead.
+						// The trigger source must be set to 'Software'.
+                        //CEnumParameter(nodemap, "TriggerSource").SetValue("Software");
+
+                        //// Alternative hardware trigger configuration:
+                        //// This configuration can be copied and modified to create a hardware trigger configuration.
+                        //// Remove setting the 'TriggerSource' to 'Software' (see above) and
+                        //// use the commented lines as a starting point.
+                        //// The camera user's manual contains more information about available configurations.
+                        //// The Basler pylon Viewer tool can be used to test the selected settings first.
+
+                        //// The trigger source must be set to the trigger input, e.g. 'Line1'.
+                        CEnumParameter(nodemap, "TriggerSource").SetValue("Line1");
+
+                        ////The trigger activation must be set to e.g. 'RisingEdge'.
+                        CEnumParameter(nodemap, "TriggerActivation").SetValue("RisingEdge");
+                    }
+                    else
+                    {
+                        triggerMode.SetValue("Off");
+                    }
+                }
+                // Finally select the frame trigger type (resp. acquisition start type
+                // for older cameras). Issuing a software trigger will now trigger
+                // the acquisition of a frame.
+                triggerSelector.SetValue(triggerName);
+            }
+
+
+            //Set acquisition mode to "continuous"
+            CEnumParameter(nodemap, "AcquisitionMode").SetValue("Continuous");
+        }
+
+        //Set basic camera settings.
+        virtual void OnOpened( CInstantCamera& camera)
+        {
+            try
+            {
+                ApplyConfiguration( camera.GetNodeMap());
+            }
+            catch (const GenericException& e)
+            {
+                throw RUNTIME_EXCEPTION( "Could not apply configuration. Pylon::GenericException caught in OnOpened method msg=%hs", e.what());
+            }
+            catch (const std::exception& e)
+            {
+                throw RUNTIME_EXCEPTION( "Could not apply configuration. std::exception caught in OnOpened method msg=%hs", e.what());
+            }
+            catch (...)
+            {
+                throw RUNTIME_EXCEPTION( "Could not apply configuration. Unknown exception caught in OnOpened method.");
+            }
+        }
+    };
+
+    /**
+     * @}
+     */
+}
+
+#ifdef _MSC_VER
+#   pragma pack(pop)
+#endif /* _MSC_VER */
+

--- a/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -67,8 +67,8 @@ template <typename CameraTraitT>
 bool PylonCameraImpl<CameraTraitT>::registerCameraConfiguration()
 {
     try
-    {
-        cam_->RegisterConfiguration(new Pylon::CSoftwareTriggerConfiguration,
+    {// CHANGED BY NEEL1302: REPLACE CAcquireContinuous... with Pylon::CSoftwareTriggerConfiguration TO REVERT TO ORIGINAL (TOTAL 2 FILES CHANGED - OTHER FILE IS pylon_camera_usb.hpp)
+        cam_->RegisterConfiguration(new Pylon::CAcquireContinuousConfiguration,
                                         Pylon::RegistrationMode_ReplaceAll,
                                         Pylon::Cleanup_Delete);
         return true;
@@ -461,22 +461,27 @@ bool PylonCameraImpl<CameraTrait>::grab(Pylon::CGrabResultPtr& grab_result)
     try
     {
         int timeout = 5000;  // ms
+        // Changed by NEEL1302: UNCOMMENT COMMENTED BLOCK BELOW TO REVERT TO ORIGINAL:
         // WaitForFrameTriggerReady to prevent trigger signal to get lost
         // this could happen, if 2xExecuteSoftwareTrigger() is only followed by 1xgrabResult()
         // -> 2nd trigger might get lost
-        if ((cam_->TriggerMode.GetValue() == TriggerModeEnums::TriggerMode_On))
-        {
-        if ( cam_->WaitForFrameTriggerReady(timeout, Pylon::TimeoutHandling_ThrowException) )
-        {   
-            cam_->ExecuteSoftwareTrigger(); 
-        }
-        else
-        {   
-            ROS_ERROR("Error WaitForFrameTriggerReady() timed out, impossible to ExecuteSoftwareTrigger()");
-            return false;
-        }   
-    }
-        cam_->RetrieveResult(grab_timeout_, grab_result, Pylon::TimeoutHandling_ThrowException); 
+        // if ( cam_->WaitForFrameTriggerReady(timeout, Pylon::TimeoutHandling_ThrowException) )
+        // {
+        //     cam_->ExecuteSoftwareTrigger();
+        // }
+        // else
+        // {
+        //     ROS_ERROR("Error WaitForFrameTriggerReady() timed out, impossible to ExecuteSoftwareTrigger()");
+        //     return false;
+        // }
+        // cam_->StartGrabbing();
+
+        // ADDED BY NEEL1302: DEBUGGING 2 LINES and then 2 LINES after cam_->RetrieveRESULT(...);
+        // std::cout << cam_->IsGrabbing() << std::endl;
+        // std::cout << "---- Entered -----" << std::endl;
+        cam_->RetrieveResult(grab_timeout_, grab_result, Pylon::TimeoutHandling_ThrowException);
+        // std::cout << currentExposure() << std::endl;
+        // std::cout << "---- Ran -----" << std::endl; 
     }
     catch ( const GenICam::GenericException &e )
     {   

--- a/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -67,8 +67,8 @@ template <typename CameraTraitT>
 bool PylonCameraImpl<CameraTraitT>::registerCameraConfiguration()
 {
     try
-    {// CHANGED BY NEEL1302: REPLACE CAcquireContinuous... with Pylon::CSoftwareTriggerConfiguration TO REVERT TO ORIGINAL (TOTAL 2 FILES CHANGED - OTHER FILE IS pylon_camera_usb.hpp)
-        cam_->RegisterConfiguration(new Pylon::CAcquireContinuousConfiguration,
+    {// CHANGED BY NEEL1302: REPLACE CHardwareTriggerConfiguration... with Pylon::CSoftwareTriggerConfiguration TO REVERT TO ORIGINAL (TOTAL 2 FILES CHANGED - OTHER FILE IS pylon_camera_usb.hpp)
+        cam_->RegisterConfiguration(new Pylon::CHardwareTriggerConfiguration,
                                         Pylon::RegistrationMode_ReplaceAll,
                                         Pylon::Cleanup_Delete);
         return true;

--- a/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
+++ b/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
@@ -92,9 +92,10 @@ bool PylonUSBCamera::applyCamSpecificStartupSettings(const PylonCameraParameter&
 
             // Remove all previous settings (sequencer etc.)
             // Default Setting = Free-Running
-            cam_->UserSetSelector.SetValue(Basler_UsbCameraParams::UserSetSelector_Default);
-            cam_->UserSetLoad.Execute();
-            // UserSetSelector_Default overrides Software Trigger Mode !!
+            // CHANGED BY NEEL: UNCOMMENT 2 LINES BELOW TO REVERT TO  ORIGINAL
+//             cam_->UserSetSelector.SetValue(Basler_UsbCameraParams::UserSetSelector_Default);
+//             cam_->UserSetLoad.Execute();
+//                UserSetSelector_Default overrides Software Trigger Mode !!
 //             CHANGED BY NEEL1302: DO NOT SET SOFTWARE TRIGGER MODE - UNCOMMENT 2 LINES BELOW TO REVERT TO ORIGINAL
 //             cam_->TriggerSource.SetValue(Basler_UsbCameraParams::TriggerSource_Software);
 //             cam_->TriggerMode.SetValue(Basler_UsbCameraParams::TriggerMode_On);

--- a/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
+++ b/pylon_camera/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
@@ -95,8 +95,9 @@ bool PylonUSBCamera::applyCamSpecificStartupSettings(const PylonCameraParameter&
             cam_->UserSetSelector.SetValue(Basler_UsbCameraParams::UserSetSelector_Default);
             cam_->UserSetLoad.Execute();
             // UserSetSelector_Default overrides Software Trigger Mode !!
-            cam_->TriggerSource.SetValue(Basler_UsbCameraParams::TriggerSource_Software);
-            cam_->TriggerMode.SetValue(Basler_UsbCameraParams::TriggerMode_On);
+//             CHANGED BY NEEL1302: DO NOT SET SOFTWARE TRIGGER MODE - UNCOMMENT 2 LINES BELOW TO REVERT TO ORIGINAL
+//             cam_->TriggerSource.SetValue(Basler_UsbCameraParams::TriggerSource_Software);
+//             cam_->TriggerMode.SetValue(Basler_UsbCameraParams::TriggerMode_On);
 
              /* Thresholds for the AutoExposure Functions:
               *  - lower limit can be used to get rid of changing light conditions


### PR DESCRIPTION
Objective: Add Hardware Trigger Support

Summary of changes:
1. `pylon_camera_base.hpp`:
Modified RegisterConfiguration to accept custom Hardware Trigger Configuration:
```
       cam_->RegisterConfiguration(new Pylon::CHardwareTriggerConfiguration,
                                        Pylon::RegistrationMode_ReplaceAll,
                                        Pylon::Cleanup_Delete);
```
**Note:**
Need to add `HardwareTriggerConfiguration.h` in `/opt/pylon5/include/pylon/` . In addition, need to include add: `#include <pylon/HardwareTriggerConfiguration.h>` to `/opt/pylon5/include/pylon/PylonIncludes.h`

2. `pylon_camera_usb.hpp`:
Commented out:
```
        cam_->UserSetSelector.SetValue(Basler_UsbCameraParams::UserSetSelector_Default);
        cam_->UserSetLoad.Execute();
```
This is so that the trigger mode settings are not reset after they are registered using the hardware configuration.

Please check extended descriptions of file commits: