### PR TITLE
Added script to set user id by camera serial number

### DIFF
--- a/pylon_camera/CMakeLists.txt
+++ b/pylon_camera/CMakeLists.txt
@@ -52,6 +52,8 @@ roslint_cpp(
     src/${PROJECT_NAME}/${PROJECT_NAME}_parameter.cpp
     src/${PROJECT_NAME}/${PROJECT_NAME}.cpp
     src/${PROJECT_NAME}/write_device_user_id_to_camera.cpp
+    src/${PROJECT_NAME}/set_user_id_by_serial.cpp
+
     src/${PROJECT_NAME}/IPConfigAuto.cpp
     include/${PROJECT_NAME}/binary_exposure_search.h
     include/${PROJECT_NAME}/encoding_conversions.h
@@ -111,12 +113,22 @@ add_executable(
 )
 
 add_executable(
+    set_user_id_by_serial
+     src/${PROJECT_NAME}/set_user_id_by_serial.cpp
+)
+
+add_executable(
     IPConfigAuto
      src/${PROJECT_NAME}/IPConfigAuto.cpp
 )
 
 target_link_libraries(
     write_device_user_id_to_camera
+     ${Pylon_LIBRARIES}
+)
+
+target_link_libraries(
+    set_user_id_by_serial
      ${Pylon_LIBRARIES}
 )
 
@@ -172,6 +184,7 @@ install(
      ${PROJECT_NAME}
      ${PROJECT_NAME}_node
      write_device_user_id_to_camera
+     set_user_id_by_serial
      IPConfigAuto
     LIBRARY DESTINATION
      ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/pylon_camera/src/pylon_camera/set_user_id_by_serial.cpp
+++ b/pylon_camera/src/pylon_camera/set_user_id_by_serial.cpp
@@ -1,0 +1,69 @@
+#include <pylon/PylonIncludes.h>
+#include <algorithm>
+#include <unistd.h>
+#include <string>
+
+int main(int argc, char* argv[])
+{
+    if ( argc < 3 )
+    {
+        std::cerr << "ERROR: Not enough parameters!" << std::endl;
+        std::cout << "USAGE: set_user_id_to_camera SERIAL DEVICE_USER_ID" << std::endl;
+        return 1;
+    }
+
+    std::string desired_device_user_id(reinterpret_cast<char *>(argv[2]));
+    if ( desired_device_user_id.empty() )
+    {
+        std::cout << "ERROR:" << std::endl;
+        std::cout << "Your desired device_user_id is empty!" << std::endl;
+        return 2;
+    }
+
+    std::string serial(reinterpret_cast<char *>(argv[1]));
+    if ( serial.empty() )
+    {
+        std::cout << "ERROR:" << std::endl;
+        std::cout << "Your serial is empty!" << std::endl;
+        return 2;
+    }
+
+    Pylon::PylonInitialize();
+
+    try {
+        Pylon::CTlFactory &tl_factory = Pylon::CTlFactory::GetInstance();
+
+        Pylon::DeviceInfoList_t devices;
+        if (tl_factory.EnumerateDevices(devices) == 0) {
+            std::cout << "No cameras detected!" << std::endl;
+            return false;
+        }
+        size_t i = 0;
+        for (i; i < devices.size(); i++) {
+            Pylon::CDeviceInfo &dev_info = devices[i];
+            std::string serial_number(dev_info.GetSerialNumber().c_str());
+
+            if(serial_number == serial){
+                Pylon::CInstantCamera dev(tl_factory.CreateDevice(dev_info));
+                dev.Open();
+                GenApi::INodeMap& node_map = dev.GetNodeMap();
+                GenApi::CStringPtr current_device_user_id(node_map.GetNode("DeviceUserID"));
+                current_device_user_id->SetValue(Pylon::String_t(desired_device_user_id.c_str()));
+
+                std::cout << "Successfully wrote " << current_device_user_id->GetValue() << " to the camera "
+                  << dev.GetDeviceInfo().GetModelName() << std::endl;
+                dev.Close();
+                break;
+            }
+        }
+        if (i == devices.size())
+            std::cout << "Camera with serial " << serial << " not found!\n\nVerify serial with \n\tlsusb -v | grep Serial" << std::endl;
+    } catch (GenICam::GenericException &e) {
+        std::cout << "Exception occured: " << e.what() << std::endl;
+    return false;
+    }
+    // Releases all pylon resources.
+    Pylon::PylonTerminate();
+
+    return 0;
+}


### PR DESCRIPTION
# Description
When working with more than one USB camera it is not possible to use the ´write_device_user_id_to_camera´ script without reconnecting the cameras one-by-one and calling the script. This pull request adds the possibility to setup the user ids for several cameras without disconnecting them.

Usage:

´set_user_id_to_camera SERIAL DEVICE_USER_ID´

# Example
Find the serial number for each camera in question with ´lsusb -v | grep Serial´ or by using the PylonViewerApp.

Run
set_user_id_to_camera 123451 front
set_user_id_to_camera 123452 rear

