### PR TITLE
Allow GrabImages service without requesting specific parameters

### DIFF
--- a/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
@@ -383,7 +383,7 @@ bool PylonCameraNode::startGrabbing()
     {
         std::string srv_name = "set_user_output_" + std::to_string(i);
         std::string srv_name_af = "activate_autoflash_output_" + std::to_string(i);
-        if (! ros::service::exists(srv_name, false))
+        if (! ros::service::exists("~" + srv_name, false))
         {
         set_user_output_srvs_.at(i) =
             nh_.advertiseService< std_srvs::SetBool::Request,
@@ -392,7 +392,7 @@ bool PylonCameraNode::startGrabbing()
                                     boost::bind(&PylonCameraNode::setUserOutputCB,
                                                 this, i ,_1 ,_2));
         }
-        if (! ros::service::exists(srv_name_af, false))
+        if (! ros::service::exists("~" + srv_name_af, false))
         {
         set_user_output_srvs_.at(num_user_outputs+i) =
             nh_.advertiseService< std_srvs::SetBool::Request,

--- a/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
@@ -802,7 +802,8 @@ camera_control_msgs::GrabImagesResult PylonCameraNode::grabImagesRaw(
     candidates.at(2) = goal->brightness_given ? goal->brightness_values.size() : 0;
     candidates.at(3) = goal->gamma_given ? goal->gamma_values.size() : 0;
 
-    size_t n_images = *std::max_element(candidates.begin(), candidates.end());
+    // Minimum of 1, in case user does not wish to target any parameters
+    size_t n_images = max(1, *std::max_element(candidates.begin(), candidates.end()));
 
     if ( goal->exposure_given && goal->exposure_times.size() != n_images )
     {

--- a/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
@@ -803,7 +803,8 @@ camera_control_msgs::GrabImagesResult PylonCameraNode::grabImagesRaw(
     candidates.at(3) = goal->gamma_given ? goal->gamma_values.size() : 0;
 
     // Minimum of 1, in case user does not wish to target any parameters
-    size_t n_images = max(1, *std::max_element(candidates.begin(), candidates.end()));
+    size_t n_images = *std::max_element(candidates.begin(), candidates.end());
+    if (n_images == 0) n_images = 1;
 
     if ( goal->exposure_given && goal->exposure_times.size() != n_images )
     {

--- a/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
@@ -383,7 +383,7 @@ bool PylonCameraNode::startGrabbing()
     {
         std::string srv_name = "set_user_output_" + std::to_string(i);
         std::string srv_name_af = "activate_autoflash_output_" + std::to_string(i);
-        if (! ros::service::exists("/pylon_camera_node/"+srv_name, false))
+        if (! ros::service::exists(srv_name, false))
         {
         set_user_output_srvs_.at(i) =
             nh_.advertiseService< std_srvs::SetBool::Request,
@@ -392,7 +392,7 @@ bool PylonCameraNode::startGrabbing()
                                     boost::bind(&PylonCameraNode::setUserOutputCB,
                                                 this, i ,_1 ,_2));
         }
-        if (! ros::service::exists("/pylon_camera_node/"+srv_name_af, false))
+        if (! ros::service::exists(srv_name_af, false))
         {
         set_user_output_srvs_.at(num_user_outputs+i) =
             nh_.advertiseService< std_srvs::SetBool::Request,

--- a/pylon_camera/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_parameter.cpp
@@ -97,7 +97,7 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     {
         int binning_x;
         nh.getParam("binning_x", binning_x);
-        std::cout << "binning x is given and has value " << binning_x << std::endl;
+        ROS_DEBUG_STREAM("binning x is given and has value " << binning_x);
         if ( binning_x > 32 || binning_x < 0 )
         {
             ROS_WARN_STREAM("Desired horizontal binning_x factor not in valid "
@@ -115,7 +115,7 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     {
         int binning_y;
         nh.getParam("binning_y", binning_y);
-        std::cout << "binning y is given and has value " << binning_y << std::endl;
+        ROS_DEBUG_STREAM("binning y is given and has value " << binning_y);
         if ( binning_y > 32 || binning_y < 0 )
         {
             ROS_WARN_STREAM("Desired vertical binning_y factor not in valid "
@@ -159,29 +159,28 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     if ( exposure_given_ )
     {
         nh.getParam("exposure", exposure_);
-        std::cout << "exposure is given and has value " << exposure_ << std::endl;
+        ROS_DEBUG_STREAM("exposure is given and has value " << exposure_);
     }
 
     gain_given_ = nh.hasParam("gain");
     if ( gain_given_ )
     {
         nh.getParam("gain", gain_);
-        std::cout << "gain is given and has value " << gain_ << std::endl;
+        ROS_DEBUG_STREAM("gain is given and has value " << gain_);
     }
 
     gamma_given_ = nh.hasParam("gamma");
     if ( gamma_given_ )
     {
         nh.getParam("gamma", gamma_);
-        std::cout << "gamma is given and has value " << gamma_ << std::endl;
+        ROS_DEBUG_STREAM("gamma is given and has value " << gamma_);
     }
 
     brightness_given_ = nh.hasParam("brightness");
     if ( brightness_given_ )
     {
         nh.getParam("brightness", brightness_);
-        std::cout << "brightness is given and has value " << brightness_
-            << std::endl;
+        ROS_DEBUG_STREAM("brightness is given and has value " << brightness_);
         if ( gain_given_ && exposure_given_ )
         {
             ROS_WARN_STREAM("Gain ('gain') and Exposure Time ('exposure') "
@@ -196,17 +195,17 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
             if ( nh.hasParam("brightness_continuous") )
             {
                 nh.getParam("brightness_continuous", brightness_continuous_);
-                std::cout << "brightness is continuous" << std::endl;
+                ROS_DEBUG_STREAM("brightness is continuous");
             }
             if ( nh.hasParam("exposure_auto") )
             {
                 nh.getParam("exposure_auto", exposure_auto_);
-                std::cout << "exposure is set to auto" << std::endl;
+                ROS_DEBUG_STREAM("exposure is set to auto");
             }
             if ( nh.hasParam("gain_auto") )
             {
                 nh.getParam("gain_auto", gain_auto_);
-                std::cout << "gain is set to auto" << std::endl;
+                ROS_DEBUG_STREAM("gain is set to auto");
             }
         }
     }


### PR DESCRIPTION
Put a minimum in number of images to grab with GrabImages service, in case user does not wish to target any parameters