### PR TITLE
Check if mage_raw or image_rec is published

### DIFF
--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -814,7 +814,7 @@ void PylonROS2CameraNode::spin()
       }
     }
 
-    if (this->img_raw_pub_.getNumSubscribers() > 0)
+    if (this->img_raw_pub_.getNumSubscribers()+img_rect_pub_->getNumSubscribers() > 0)
     {
       // get actual cam_info-object in every frame, because it might have
       // changed due to a 'set_camera_info'-service call


### PR DESCRIPTION
Also done in master; see
https://github.com/basler/pylon-ros-camera/blob/master/pylon_camera/src/pylon_camera/pylon_camera_node.cpp, 
line 738(there) matches our line 817, but their "getNumSubscribers() refers to line 1088, which is a summation of raw and rectified images