### PR TITLE
Allow installing via rosdep without explicit sudo

### DIFF
--- a/pylon_camera/rosdep/pylon_sdk.rdmanifest
+++ b/pylon_camera/rosdep/pylon_sdk.rdmanifest
@@ -34,8 +34,12 @@ install-script: |
   url="https://dnb-public-downloads-misc.s3.eu-central-1.amazonaws.com/pylon/${pkg}"
 
   wget --no-check-certificate -O $pkg $url
-  dpkg -i $pkg
-  udevadm control --reload-rules || true
+  SUDO=
+  if [ "$(id -u)" -ne 0 ]; then
+    SUDO=sudo
+  fi
+  $SUDO dpkg -i $pkg
+  $SUDO udevadm control --reload-rules || true
 
 check-presence-script: |
   #!/bin/bash

--- a/pylon_camera/rosdep/pylon_sdk.yaml
+++ b/pylon_camera/rosdep/pylon_sdk.yaml
@@ -1,4 +1,4 @@
 pylon:
   ubuntu:
     source:
-      uri: "https://raw.githubusercontent.com/dragandbot/pylon-ros-camera/pylon6-dev/pylon_camera/rosdep/pylon_sdk.rdmanifest"
+      uri: "https://raw.githubusercontent.com/basler/pylon-ros-camera/master/pylon_camera/rosdep/pylon_sdk.rdmanifest"


### PR DESCRIPTION
Fixes #96.

I understand you want to be able to install in a sudo-less container, but the idiomatic way used throughout all ROS is running rosdep install without sudo.

This PR allows both.