### PR TITLE
Fix camera_info publishing

### DIFF
--- a/pylon_camera/include/pylon_camera/pylon_camera_node.h
+++ b/pylon_camera/include/pylon_camera/pylon_camera_node.h
@@ -1226,7 +1226,8 @@ protected:
     PylonCamera* pylon_camera_;
 
     image_transport::ImageTransport* it_;
-    image_transport::CameraPublisher img_raw_pub_;
+    image_transport::Publisher img_raw_pub_;
+    ros::Publisher camera_info_pub_;
 
     image_transport::Publisher* img_rect_pub_;
     image_geometry::PinholeCameraModel* pinhole_model_;

--- a/pylon_camera/include/pylon_camera/pylon_camera_node.h
+++ b/pylon_camera/include/pylon_camera/pylon_camera_node.h
@@ -142,6 +142,11 @@ protected:
     uint32_t getNumSubscribersRect() const;
 
     /**
+     * Returns the number of subscribers for the camera info topic
+     */
+    uint32_t getNumSubscribersInfo() const;
+
+    /**
      * Grabs an image and stores the image in img_raw_msg_
      * @return false if an error occurred.
      */


### PR DESCRIPTION
Currently, camera_info only gets published if there is a subscriber for image_raw, since they are bundled with a camera publisher. However, I have an application that only needs the rectified image, but also the camera info. In this case, the camera info is not received.

I changed the node so that the camera_info is published separately if there is no image_raw subscriber, but a camera_info subscriber. Additionally, the subscriber count is now only retrieved once before grabbing the image, because otherwise, there could potentially be a race condition when a subscriber is added after checking if an image needs to be grabbed.