### PR TITLE
[humble] added OpenDrain to the allowed LineFormat conditions for setLineMode

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -2187,9 +2187,14 @@ template <typename CameraTraitT>
 std::string PylonROS2CameraImpl<CameraTraitT>::setLineMode(const int& value)
 {
     try
-    {   if ( (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_TTL) ||
-             (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_LVTTL) ||
-             (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_OpenDrain) )
+    {   
+        LineFormatEnums lineFormat = cam_->LineFormat.GetValue();
+        std::unordered_set<LineFormatEnums> validLineFormats = {
+            LineFormatEnums::LineFormat_TTL,
+            LineFormatEnums::LineFormat_LVTTL,
+            LineFormatEnums::LineFormat_OpenDrain
+        };        
+        if (validLineFormats.count(lineFormat) > 0)
         {
             if (value == 0)
             {

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -2187,7 +2187,9 @@ template <typename CameraTraitT>
 std::string PylonROS2CameraImpl<CameraTraitT>::setLineMode(const int& value)
 {
     try
-    {   if ( (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_TTL) || (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_LVTTL) )
+    {   if ( (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_TTL) ||
+             (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_LVTTL) ||
+             (cam_->LineFormat.GetValue() == LineFormatEnums::LineFormat_OpenDrain) )
         {
             if (value == 0)
             {


### PR DESCRIPTION
I am using the a2A4504-18umPRO camera and I want to set the line mode to output. This is doable through the pylon viewer and I have already tested everything in my system and it works fine. However, the wrapper was missing this condition.