### PR TITLE
[humble] stop grabbing in order to set the user set 

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -2614,6 +2614,7 @@ std::string PylonROS2CameraImpl<CameraTraitT>::setUserSetSelector(const int& set
 {
     try
     {
+        grabbingStopping();
         if ( GenApi::IsAvailable(cam_->UserSetSelector))
         {  
             if (set == 0)
@@ -2654,6 +2655,7 @@ std::string PylonROS2CameraImpl<CameraTraitT>::setUserSetSelector(const int& set
              RCLCPP_ERROR_STREAM(LOGGER_BASE, "Error while trying to select the user set. The connected Camera not supporting this feature");
              return "The connected Camera not supporting this feature";
         }
+        grabbingStarting();
     }
     catch ( const GenICam::GenericException &e )
     {


### PR DESCRIPTION
It was not possible to set the user set because of grabbing. So these two had to be added to allow setting the user set while the node is running.