### PR TITLE
[Humble] Get, save and load pfs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ Name          | Notes
 /my_camera/pylon_ros2_camera_node/issue_scheduled_action_command  | -
 /my_camera/pylon_ros2_camera_node/list_parameters  | -
 /my_camera/pylon_ros2_camera_node/load_user_set  | -
+/my_camera/pylon_ros2_camera_node/get_pfs  | -
+/my_camera/pylon_ros2_camera_node/save_pfs  | value : '/path/to/your/output.pfs'
+/my_camera/pylon_ros2_camera_node/load_pfs  | value : '/path/to/your/input.pfs'
 /my_camera/pylon_ros2_camera_node/reset_device  | -
 /my_camera/pylon_ros2_camera_node/save_user_set  | -
 /my_camera/pylon_ros2_camera_node/set_PGI_mode  | data : false = deactivate, true = activate

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -2777,7 +2777,7 @@ std::string PylonROS2CameraImpl<CameraTraitT>::savePfs(const std::string& fileNa
     {
         grabbingStopping();
         Pylon::String_t fileNameCStr = fileName.c_str();
-        RCLCPP_ERROR_STREAM(LOGGER_BASE, "Saving the pfs file: " << fileNameCStr );
+        RCLCPP_INFO_STREAM(LOGGER_BASE, "Saving the pfs file: " << fileNameCStr );
         Pylon::CFeaturePersistence::Save(fileNameCStr, &cam_->GetNodeMap());
         grabbingStarting();
     }
@@ -2796,7 +2796,7 @@ std::string PylonROS2CameraImpl<CameraTraitT>::loadPfs(const std::string& fileNa
     {
         grabbingStopping();
         Pylon::String_t fileNameCStr = fileName.c_str();
-        RCLCPP_ERROR_STREAM(LOGGER_BASE, "Loading the pfs file: " << fileNameCStr );
+        RCLCPP_INFO_STREAM(LOGGER_BASE, "Loading the pfs file: " << fileNameCStr );
         Pylon::CFeaturePersistence::Load(fileNameCStr, &cam_->GetNodeMap(), true);
         grabbingStarting();
     }

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -2749,6 +2749,25 @@ std::string PylonROS2CameraImpl<CameraTraitT>::loadUserSet()
 }
 
 template <typename CameraTraitT>
+std::string PylonROS2CameraImpl<CameraTraitT>::savePfs(const std::string& fileName)
+{
+    try
+    {
+        grabbingStopping();
+        Pylon::String_t fileNameCStr = fileName.c_str();
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "Saving the pfs file: " << fileNameCStr );
+        Pylon::CFeaturePersistence::Save(fileNameCStr, &cam_->GetNodeMap());
+        grabbingStarting();
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "An exception while saving the pfs file:" << e.GetDescription());
+        return e.GetDescription();
+    }
+    return "done";
+}
+
+template <typename CameraTraitT>
 std::string PylonROS2CameraImpl<CameraTraitT>::loadPfs(const std::string& fileName)
 {
     try

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -2749,6 +2749,25 @@ std::string PylonROS2CameraImpl<CameraTraitT>::loadUserSet()
 }
 
 template <typename CameraTraitT>
+std::string PylonROS2CameraImpl<CameraTraitT>::loadPfs(const std::string& fileName)
+{
+    try
+    {
+        grabbingStopping();
+        Pylon::String_t fileNameCStr = fileName.c_str();
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "Loading the pfs file: " << fileNameCStr );
+        Pylon::CFeaturePersistence::Load(fileNameCStr, &cam_->GetNodeMap(), true);
+        grabbingStarting();
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "An exception while loading the pfs file:" << e.GetDescription());
+        return e.GetDescription();
+    }
+    return "done";
+}
+
+template <typename CameraTraitT>
 std::string PylonROS2CameraImpl<CameraTraitT>::setUserSetDefaultSelector(const int& set)
 {
     try

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -2749,6 +2749,28 @@ std::string PylonROS2CameraImpl<CameraTraitT>::loadUserSet()
 }
 
 template <typename CameraTraitT>
+std::pair<std::string, std::string> PylonROS2CameraImpl<CameraTraitT>::getPfs()
+{
+    std::pair<std::string, std::string> stringResults;
+    try
+    {
+        grabbingStopping();
+        Pylon::String_t cameraPfsString;
+        Pylon::CFeaturePersistence::SaveToString(cameraPfsString, &cam_->GetNodeMap());
+        stringResults.second = cameraPfsString; 
+        grabbingStarting();
+    }
+    catch ( const GenICam::GenericException &e )
+    {
+        RCLCPP_ERROR_STREAM(LOGGER_BASE, "An exception while getting camera configuration as pfs:" << e.GetDescription());
+        stringResults.first = e.GetDescription();
+        return stringResults;
+    }
+    stringResults.first = "done";
+    return stringResults;
+}
+
+template <typename CameraTraitT>
 std::string PylonROS2CameraImpl<CameraTraitT>::savePfs(const std::string& fileName)
 {
     try

--- a/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
+++ b/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
@@ -230,6 +230,8 @@ public:
 
     virtual std::string loadUserSet();
 
+    virtual std::string savePfs(const std::string& fileName);
+
     virtual std::string loadPfs(const std::string& fileName);
 
     virtual std::string setUserSetDefaultSelector(const int& set);

--- a/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
+++ b/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
@@ -230,6 +230,8 @@ public:
 
     virtual std::string loadUserSet();
 
+    virtual std::pair<std::string, std::string> getPfs();
+
     virtual std::string savePfs(const std::string& fileName);
 
     virtual std::string loadPfs(const std::string& fileName);

--- a/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
+++ b/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
@@ -230,6 +230,8 @@ public:
 
     virtual std::string loadUserSet();
 
+    virtual std::string loadPfs(const std::string& fileName);
+
     virtual std::string setUserSetDefaultSelector(const int& set);
 
     virtual int getUserSetDefaultSelector();

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -721,6 +721,12 @@ public:
     virtual std::string loadUserSet() = 0;
 
     /**
+     * load pfs file
+     * @return error message if an error occurred or done message otherwise.
+     */
+    virtual std::string loadPfs(const std::string& fileName) = 0;
+
+    /**
      * set camera user set default selector
      * @param set : 0 = Default, 1 = UserSet1, 2 = UserSet2, 3 = UserSet3, 4 = HighGain, 5 = AutoFunctions, 6 = ColorRaw
      * @return error message if an error occurred or done message otherwise.

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -722,7 +722,7 @@ public:
 
     /**
      * get camera configuration as pfs
-     * @return camera configuration as pfs .
+     * @return  A pair of strings. First string: error message if an error occurred or done message otherwise. Second string: camera configuration as pfs (if first is done).
      */
     virtual std::pair<std::string, std::string> getPfs() = 0;
 

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -721,6 +721,12 @@ public:
     virtual std::string loadUserSet() = 0;
 
     /**
+     * get camera configuration as pfs
+     * @return camera configuration as pfs .
+     */
+    virtual std::pair<std::string, std::string> getPfs() = 0;
+
+    /**
      * save pfs file
      * @return error message if an error occurred or done message otherwise.
      */

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -721,6 +721,12 @@ public:
     virtual std::string loadUserSet() = 0;
 
     /**
+     * save pfs file
+     * @return error message if an error occurred or done message otherwise.
+     */
+    virtual std::string savePfs(const std::string& fileName) = 0;
+
+    /**
      * load pfs file
      * @return error message if an error occurred or done message otherwise.
      */

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -728,12 +728,14 @@ public:
 
     /**
      * save pfs file
+     * @param fileName : Path to the pfs file to be saved
      * @return error message if an error occurred or done message otherwise.
      */
     virtual std::string savePfs(const std::string& fileName) = 0;
 
     /**
      * load pfs file
+     * @param fileName : Path to the pfs file to be loaded
      * @return error message if an error occurred or done message otherwise.
      */
     virtual std::string loadPfs(const std::string& fileName) = 0;

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -432,6 +432,12 @@ protected:
   std::string loadUserSet();
 
   /**
+   * @brief Method to load a pfs file
+   * @return error message if an error occurred or done message otherwise.
+   */
+  std::string loadPfs(const std::string& fileName);
+
+  /**
    * @brief Method to set camera user set default selector
    * @param set : 0 = Default, 1 = UserSet1, 2 = UserSet2, 3 = UserSet3, 4 = HighGain, 5 = AutoFunctions, 6 = ColorRaw
    * @return error message if an error occurred or done message otherwise.
@@ -1207,6 +1213,14 @@ protected:
    */
   void loadUserSetCallback(const std::shared_ptr<TriggerSrv::Request> request,
                            std::shared_ptr<TriggerSrv::Response> response);
+
+  /**
+   * @brief Service callback for loading a pfs file
+   * @param req request
+   * @param res response
+   */
+  void loadPfsCallback(const std::shared_ptr<SetStringSrv::Request> request,
+                           std::shared_ptr<SetStringSrv::Response> response);
 
   /**
    * @brief Service callback for reseting the camera device

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -44,6 +44,7 @@
 // services
 #include "pylon_ros2_camera_interfaces/srv/get_integer_value.hpp"
 #include "pylon_ros2_camera_interfaces/srv/get_float_value.hpp"
+#include "pylon_ros2_camera_interfaces/srv/get_string_value.hpp"
 #include "pylon_ros2_camera_interfaces/srv/set_binning.hpp"
 #include "pylon_ros2_camera_interfaces/srv/set_brightness.hpp"
 #include "pylon_ros2_camera_interfaces/srv/set_exposure.hpp"
@@ -87,6 +88,7 @@ namespace pylon_ros2_camera
 
 using GetIntegerSrv                 = pylon_ros2_camera_interfaces::srv::GetIntegerValue;
 using GetFloatSrv                   = pylon_ros2_camera_interfaces::srv::GetFloatValue;
+using GetStringSrv                  = pylon_ros2_camera_interfaces::srv::GetStringValue;
 
 using SetBinningSrv                 = pylon_ros2_camera_interfaces::srv::SetBinning;
 using SetBrightnessSrv              = pylon_ros2_camera_interfaces::srv::SetBrightness;
@@ -430,6 +432,12 @@ protected:
    * @return error message if an error occurred or done message otherwise.
    */
   std::string loadUserSet();
+
+  /**
+   * @brief Method to get camera configuration as pfs
+   * @return error message if an error occurred or done message otherwise.
+   */
+  std::pair<std::string, std::string> getPfs();
 
   /**
    * @brief Method to save a pfs file
@@ -1221,6 +1229,14 @@ protected:
                            std::shared_ptr<TriggerSrv::Response> response);
 
   /**
+   * @brief Service callback for getting camera configuration in pfs format
+   * @param req request
+   * @param res response
+   */
+  void getPfsCallback(const std::shared_ptr<GetStringSrv::Request> request,
+                           std::shared_ptr<GetStringSrv::Response> response);
+
+  /**
    * @brief Service callback for saving a pfs file
    * @param req request
    * @param res response
@@ -1458,6 +1474,8 @@ protected:
   rclcpp::Service<GetIntegerSrv>::SharedPtr get_chunk_counter_value_srv_;
   
   rclcpp::Service<GetFloatSrv>::SharedPtr get_chunk_exposure_time_srv_;
+
+  rclcpp::Service<GetStringSrv>::SharedPtr get_pfs_srv_;
   
   rclcpp::Service<SetBinningSrv>::SharedPtr set_binning_srv_;
   rclcpp::Service<SetBrightnessSrv>::SharedPtr set_brightness_srv_;

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -1520,7 +1520,7 @@ protected:
   
   rclcpp::Service<TriggerSrv>::SharedPtr execute_software_trigger_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr save_user_set_srv_;
-  rclcpp::Service<TriggerSrv>::SharedPtr load_user_set_srv_;
+  rclcpp::Service<SetStringSrv>::SharedPtr load_user_set_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr load_pfs_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr reset_device_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr start_grabbing_srv_;

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -1521,6 +1521,7 @@ protected:
   rclcpp::Service<TriggerSrv>::SharedPtr execute_software_trigger_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr save_user_set_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr load_user_set_srv_;
+  rclcpp::Service<TriggerSrv>::SharedPtr load_pfs_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr reset_device_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr start_grabbing_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr stop_grabbing_srv_;

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -435,7 +435,7 @@ protected:
 
   /**
    * @brief Method to get camera configuration as pfs
-   * @return error message if an error occurred or done message otherwise.
+   * @return A pair of strings. First string: error message if an error occurred or done message otherwise. Second string: camera configuration as pfs (if first is done).
    */
   std::pair<std::string, std::string> getPfs();
 

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -1520,8 +1520,8 @@ protected:
   
   rclcpp::Service<TriggerSrv>::SharedPtr execute_software_trigger_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr save_user_set_srv_;
-  rclcpp::Service<SetStringSrv>::SharedPtr load_user_set_srv_;
-  rclcpp::Service<TriggerSrv>::SharedPtr load_pfs_srv_;
+  rclcpp::Service<TriggerSrv>::SharedPtr load_user_set_srv_;
+  rclcpp::Service<SetStringSrv>::SharedPtr load_pfs_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr reset_device_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr start_grabbing_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr stop_grabbing_srv_;

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -432,6 +432,12 @@ protected:
   std::string loadUserSet();
 
   /**
+   * @brief Method to save a pfs file
+   * @return error message if an error occurred or done message otherwise.
+   */
+  std::string savePfs(const std::string& fileName);
+
+  /**
    * @brief Method to load a pfs file
    * @return error message if an error occurred or done message otherwise.
    */
@@ -1215,6 +1221,14 @@ protected:
                            std::shared_ptr<TriggerSrv::Response> response);
 
   /**
+   * @brief Service callback for saving a pfs file
+   * @param req request
+   * @param res response
+   */
+  void savePfsCallback(const std::shared_ptr<SetStringSrv::Request> request,
+                           std::shared_ptr<SetStringSrv::Response> response);
+
+  /**
    * @brief Service callback for loading a pfs file
    * @param req request
    * @param res response
@@ -1503,7 +1517,9 @@ protected:
   rclcpp::Service<SetFloatSrv>::SharedPtr set_sync_free_run_timer_trigger_rate_abs_srv_;
 
   rclcpp::Service<SetStringSrv>::SharedPtr set_image_encoding_srv_;
-  
+  rclcpp::Service<SetStringSrv>::SharedPtr save_pfs_srv_;
+  rclcpp::Service<SetStringSrv>::SharedPtr load_pfs_srv_;
+
   rclcpp::Service<SetBoolSrv>::SharedPtr set_reverse_x_srv_;
   rclcpp::Service<SetBoolSrv>::SharedPtr set_reverse_y_srv_;
   rclcpp::Service<SetBoolSrv>::SharedPtr set_PGI_mode_srv_;
@@ -1521,7 +1537,6 @@ protected:
   rclcpp::Service<TriggerSrv>::SharedPtr execute_software_trigger_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr save_user_set_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr load_user_set_srv_;
-  rclcpp::Service<SetStringSrv>::SharedPtr load_pfs_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr reset_device_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr start_grabbing_srv_;
   rclcpp::Service<TriggerSrv>::SharedPtr stop_grabbing_srv_;

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -441,12 +441,14 @@ protected:
 
   /**
    * @brief Method to save a pfs file
+   * @param fileName : Path to the pfs file to be saved
    * @return error message if an error occurred or done message otherwise.
    */
   std::string savePfs(const std::string& fileName);
 
   /**
    * @brief Method to load a pfs file
+   * @param fileName : Path to the pfs file to be loaded
    * @return error message if an error occurred or done message otherwise.
    */
   std::string loadPfs(const std::string& fileName);

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -435,6 +435,9 @@ void PylonROS2CameraNode::initServices()
   
   srv_name = srv_prefix + "load_user_set";
   this->load_user_set_srv_ = this->create_service<TriggerSrv>(srv_name, std::bind(&PylonROS2CameraNode::loadUserSetCallback, this, _1, _2));
+
+  srv_name = srv_prefix + "load_pfs";
+  this->load_pfs_srv_ = this->create_service<SetStringSrv>(srv_name, std::bind(&PylonROS2CameraNode::loadPfsCallback, this, _1, _2));
   
   srv_name = srv_prefix + "reset_device";
   this->reset_device_srv_ = this->create_service<TriggerSrv>(srv_name, std::bind(&PylonROS2CameraNode::triggerDeviceResetCallback, this, _1, _2));
@@ -1690,6 +1693,18 @@ std::string PylonROS2CameraNode::loadUserSet()
   }
 
   return this->pylon_camera_->loadUserSet();
+}
+
+std::string PylonROS2CameraNode::loadPfs(const std::string& fileName)
+{  
+  std::lock_guard<std::recursive_mutex> lock(this->grab_mutex_);
+  if (!this->pylon_camera_->isReady())
+  {
+    RCLCPP_WARN(LOGGER, "Error in loadPfs(): pylon_camera_ is not ready!");
+    return "pylon camera is not ready!";
+  }
+
+  return this->pylon_camera_->loadPfs(fileName);
 }
 
 std::string PylonROS2CameraNode::setUserSetDefaultSelector(const int& set)
@@ -3364,6 +3379,25 @@ void PylonROS2CameraNode::loadUserSetCallback(const std::shared_ptr<TriggerSrv::
 {
   (void)request;
   response->message = this->loadUserSet();
+  if ((response->message.find("done") != std::string::npos) != 0)
+  {
+    response->success = true;
+  }
+  else 
+  {
+    response->success = false;
+    if (response->message == "Node is not writable.")
+    {
+      response->message = "Using this feature requires stopping image grabbing";
+    }
+  }
+}
+
+void PylonROS2CameraNode::loadPfsCallback(const std::shared_ptr<SetStringSrv::Request> request,
+                                              std::shared_ptr<SetStringSrv::Response> response)
+{
+  (void)request;
+  response->message = this->loadPfs(reqest->value);
   if ((response->message.find("done") != std::string::npos) != 0)
   {
     response->success = true;

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -3397,7 +3397,7 @@ void PylonROS2CameraNode::loadPfsCallback(const std::shared_ptr<SetStringSrv::Re
                                               std::shared_ptr<SetStringSrv::Response> response)
 {
   (void)request;
-  response->message = this->loadPfs(reqest->value);
+  response->message = this->loadPfs(request->value);
   if ((response->message.find("done") != std::string::npos) != 0)
   {
     response->success = true;

--- a/pylon_ros2_camera_interfaces/CMakeLists.txt
+++ b/pylon_ros2_camera_interfaces/CMakeLists.txt
@@ -24,6 +24,7 @@ set(MSG_FILES
 set(SRV_FILES
   "srv/GetIntegerValue.srv"
   "srv/GetFloatValue.srv"
+  "srv/GetStringValue.srv"
   "srv/SetBinning.srv"
   "srv/SetBrightness.srv"
   "srv/SetExposure.srv"

--- a/pylon_ros2_camera_interfaces/srv/GetStringValue.srv
+++ b/pylon_ros2_camera_interfaces/srv/GetStringValue.srv
@@ -1,0 +1,5 @@
+
+---
+string value   # returned value
+bool success   # indicate successful run of triggered service
+string message # informational, e.g., for error messages


### PR DESCRIPTION
The purpose of this PR is to add the functionality to get, save or load camera configuration in pfs format. This is easily doable via the Pylonviewer but the functionality was missing from the wrapper. Therefore, three services were added to allow the following:

1. Getting the camera configuration in pfs format
2. Saving the camera configuration into a pfs file
3. Loading the camera configuration from a pfs file

