### PR TITLE
[Galactic] 

### DIFF
--- a/pylon_ros2_camera_component/CMakeLists.txt
+++ b/pylon_ros2_camera_component/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 find_package(Pylon QUIET)
-if (NOT ${Pylon_FOUND})
+if (NOT ${Pylon_FOUND} OR "$ENV{Pylon_INCLUDE_DIRS}" STREQUAL "")
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindPylon.cmake")
 endif()
 # message("->    Pylon include directories: ${Pylon_INCLUDE_DIRS}")

--- a/pylon_ros2_camera_component/CMakeLists.txt
+++ b/pylon_ros2_camera_component/CMakeLists.txt
@@ -116,8 +116,8 @@ ament_target_dependencies(${PROJECT_NAME}
 	${PYLON_ROS2_CAMERA_DEPENDENCIES}
 )
 
-rclcpp_components_register_nodes(${PROJECT_NAME} "pylon_ros2_camera_component::PylonROS2CameraNode")
-set(node_plugins "${node_plugins}pylon_ros2_camera_component::PylonROS2CameraNode;$<TARGET_FILE:${PROJECT_NAME}>\n")
+rclcpp_components_register_nodes(${PROJECT_NAME} "pylon_ros2_camera::PylonROS2CameraNode")
+set(node_plugins "${node_plugins}pylon_ros2_camera::PylonROS2CameraNode;$<TARGET_FILE:${PROJECT_NAME}>\n")
 
 ### tools
 


### PR DESCRIPTION
1) "FIX" [160](https://github.com/basler/pylon-ros-camera/issues/160) for the galactic branch. 
2) Fix the mismatch of rclcpp_components_register_nodes in [CMakeLists.txt](https://github.com/basler/pylon-ros-camera/blob/dd44edbc37c7b23456e98519677842fdad7d6480/pylon_ros2_camera_component/CMakeLists.txt#L119) and [pylon_ros2_camera_node.cpp](https://github.com/basler/pylon-ros-camera/blob/dd44edbc37c7b23456e98519677842fdad7d6480/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp#L4956). This addresses the ' Failed to load component: Failed to find class with the requested plugin name' error.  This error occurs when pylon_ros2_camera_component is used in composition with other components.