### PR TITLE
Use acquisition timestamp if corresponding chunk is enabled

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -395,7 +395,7 @@ bool PylonROS2CameraImpl<CameraTraitT>::startGrabbing(const PylonROS2CameraParam
         trigger_timeout = parameters.trigger_timeout_;
         
         // grab one image to be sure, that the communication is successful
-        Pylon::CGrabResultPtr grab_result;
+        Pylon::CBaslerUniversalGrabResultPtr grab_result;
         grab(grab_result);
         if ( grab_result.IsValid() )
         {
@@ -416,9 +416,9 @@ bool PylonROS2CameraImpl<CameraTraitT>::startGrabbing(const PylonROS2CameraParam
 
 // Grab a picture as std::vector of 8bits objects
 template <typename CameraTrait>
-bool PylonROS2CameraImpl<CameraTrait>::grab(std::vector<uint8_t>& image)
+bool PylonROS2CameraImpl<CameraTrait>::grab(std::vector<uint8_t>& image, rclcpp::Time &stamp)
 { 
-    Pylon::CGrabResultPtr ptr_grab_result;
+    Pylon::CBaslerUniversalGrabResultPtr ptr_grab_result;
     if ( !grab(ptr_grab_result) )
     {   
         RCLCPP_ERROR(LOGGER_BASE, "Error: Grab was not successful");
@@ -444,6 +444,34 @@ bool PylonROS2CameraImpl<CameraTrait>::grab(std::vector<uint8_t>& image)
     }
 
     delete[] shift_array;
+
+    bool use_chunk_timestamp = false;
+    if (getChunkModeActive() == 1) 
+    {
+        std::string success = setChunkSelector(29); // = ChunkSelector_Timestamp
+        if (success.find("done") != std::string::npos && getChunkEnable() == 1) 
+        {
+            use_chunk_timestamp = true;
+        }
+    }
+
+    if (use_chunk_timestamp) {
+        try
+        {
+            if (!ptr_grab_result->ChunkTimestamp.IsReadable())
+            {
+                RCLCPP_WARN_STREAM(LOGGER_BASE, "Error while trying to get the chunk timestamp. The connected camera may not support this feature");
+            }
+            else
+            {
+                stamp = rclcpp::Time(static_cast<uint64_t>(ptr_grab_result->ChunkTimestamp.GetValue()));
+            }
+        }
+        catch (const GenICam::GenericException &e)
+        {
+            RCLCPP_WARN_STREAM(LOGGER_BASE, "An exception while getting the chunk timestamp occurred: " << e.GetDescription());
+        }
+    }
     
     if ( !is_ready_ )
         is_ready_ = true;
@@ -460,7 +488,7 @@ bool PylonROS2CameraImpl<CameraTrait>::grab(uint8_t* image)
         return false;
     }
 
-    Pylon::CGrabResultPtr ptr_grab_result;
+    Pylon::CBaslerUniversalGrabResultPtr ptr_grab_result;
     if (!grab(ptr_grab_result))
     {   
         RCLCPP_ERROR(LOGGER_BASE, "Error: Grab was not successful");
@@ -500,7 +528,7 @@ bool PylonROS2CameraImpl<CameraTrait>::grabBlaze(sensor_msgs::msg::PointCloud2& 
 
 // Lowest level grab function called by the other grab functions
 template <typename CameraTrait>
-bool PylonROS2CameraImpl<CameraTrait>::grab(Pylon::CGrabResultPtr& grab_result)
+bool PylonROS2CameraImpl<CameraTrait>::grab(Pylon::CBaslerUniversalGrabResultPtr& grab_result)
 {
     // If camera is not grabbing, don't grab
     if (!cam_->IsGrabbing())

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_blaze.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_blaze.hpp
@@ -102,8 +102,8 @@ public:
                            sensor_msgs::msg::Image& depth_map_color_msg, 
                            sensor_msgs::msg::Image& confidence_map_msg);
             bool grabBlaze(Pylon::CGrabResultPtr& grab_result);
-    virtual bool grab(Pylon::CGrabResultPtr& grab_result);      // is not used but needs to be implemented
-    virtual bool grab(std::vector<uint8_t>& image);             // is not used but needs to be implemented
+    virtual bool grab(Pylon::CGrabResultPtr& grab_result);                 // is not used but needs to be implemented
+    virtual bool grab(std::vector<uint8_t>& image, rclcpp::Time &stamp);   // is not used but needs to be implemented
 
             bool processAndConvertBlazeData(const Pylon::CPylonDataContainer& container,
                                             sensor_msgs::msg::PointCloud2& cloud_msg,
@@ -1426,7 +1426,7 @@ bool PylonROS2BlazeCamera::grab(Pylon::CGrabResultPtr& grab_result)
     return true;
 }
 
-bool PylonROS2BlazeCamera::grab(std::vector<uint8_t>& image)
+bool PylonROS2BlazeCamera::grab(std::vector<uint8_t>& image, rclcpp::Time &stamp)
 {
     RCLCPP_DEBUG(LOGGER_BLAZE, "This function is not the right one to grab data from the blaze - use the function grabBlaze instead.");
     return true;

--- a/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
+++ b/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
@@ -31,6 +31,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wliteral-suffix"
 
+#include <pylon/BaslerUniversalGrabResultPtr.h>
 #include <pylon/PylonIncludes.h>
 #include <GenApi/IEnumEntry.h>
 #include <string>
@@ -68,7 +69,7 @@ public:
 
     virtual bool startGrabbing(const PylonROS2CameraParameter& parameters);
 
-    virtual bool grab(std::vector<uint8_t>& image);
+    virtual bool grab(std::vector<uint8_t>& image, rclcpp::Time &stamp);
 
     virtual bool grab(uint8_t* image);
 
@@ -460,7 +461,7 @@ protected:
     virtual bool setExtendedBrightness(const int& target_brightness,
                                        const float& current_brightness);
 
-    virtual bool grab(Pylon::CGrabResultPtr& grab_result);
+    virtual bool grab(Pylon::CBaslerUniversalGrabResultPtr& grab_result);
 
     virtual bool setupSequencer(const std::vector<float>& exposure_times,
                                 std::vector<float>& exposure_times_set);

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -119,9 +119,10 @@ public:
     /**
      * Grab a camera frame and copy the result into image
      * @param image reference to the output image.
+     * @param stamp if chunk timestamp is enabled, overwrite input stamp with the acquisition timestamp.
      * @return true if the image was grabbed successfully.
      */
-    virtual bool grab(std::vector<uint8_t>& image) = 0;
+    virtual bool grab(std::vector<uint8_t>& image, rclcpp::Time &stamp) = 0;
 
     /**
      * Grab a camera frame and copy the result into image


### PR DESCRIPTION
Hi,
We are using 4 Basler Ace cameras which are ptp synced and run synchronously. 
However I noticed that the ROS2 driver always set the timestamp of the published images using `rclcpp::Node::now()` (see [here](https://github.com/basler/pylon-ros-camera/blob/humble/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp#L1017-L1018)), instead of the acquisition time when it is available (via the [timestamp chunk](https://docs.baslerweb.com/data-chunks#timestamp-chunk)). Therefore the image timestamps do not look synchronous while the cameras are triggered synchronously.
I wrote a patch for the ROS2 driver to "fix" this. It works for our cameras but might need some more work for other camera types.
