### PR TITLE
Warn on unsupported startup profile

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige.hpp
@@ -159,8 +159,8 @@ bool PylonROS2GigECamera::applyCamSpecificStartupSettings(const PylonROS2CameraP
         //cam_->StartGrabbing();
         grabbingStarting();
         cam_->StopGrabbing();
-        
-        RCLCPP_INFO_STREAM(LOGGER_GIGE, "Startup user profile set to " << parameters.startup_user_set_);
+
+        RCLCPP_INFO_STREAM(LOGGER_GIGE, "Startup user profile set to \"" << parameters.startup_user_set_ << "\"");
         if (parameters.startup_user_set_ == "Default")
         {
             // Remove all previous settings (sequencer etc.)
@@ -272,7 +272,7 @@ bool PylonROS2GigECamera::applyCamSpecificStartupSettings(const PylonROS2CameraP
             // frame transmission delay
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
 
-            RCLCPP_WARN(LOGGER_GIGE, "Default User Setting Loaded");
+            RCLCPP_INFO(LOGGER_GIGE, "Default User Setting Loaded");
         }
         else if (parameters.startup_user_set_ == "UserSet1")
         {
@@ -282,9 +282,9 @@ bool PylonROS2GigECamera::applyCamSpecificStartupSettings(const PylonROS2CameraP
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE, "User Set 1 Loaded");
-        } 
+
+            RCLCPP_INFO(LOGGER_GIGE, "User Set 1 Loaded");
+        }
         else if (parameters.startup_user_set_ == "UserSet2")
         {
             cam_->UserSetSelector.SetValue(Basler_UniversalCameraParams::UserSetSelector_UserSet2);
@@ -293,8 +293,8 @@ bool PylonROS2GigECamera::applyCamSpecificStartupSettings(const PylonROS2CameraP
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE, "User Set 2 Loaded");
+
+            RCLCPP_INFO(LOGGER_GIGE, "User Set 2 Loaded");
         }
         else if (parameters.startup_user_set_ == "UserSet3")
         {
@@ -304,16 +304,20 @@ bool PylonROS2GigECamera::applyCamSpecificStartupSettings(const PylonROS2CameraP
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE, "User Set 3 Loaded");
+
+            RCLCPP_INFO(LOGGER_GIGE, "User Set 3 Loaded");
         }
         else if (parameters.startup_user_set_ == "CurrentSetting")
         {
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE, "No user set is provided -> Camera current setting will be applied");
+
+            RCLCPP_INFO(LOGGER_GIGE, "No user set is provided -> Camera current setting will be applied");
+        }
+        else
+        {
+            RCLCPP_WARN_STREAM(LOGGER_GIGE, "Unsupported startup user profile \"" << parameters.startup_user_set_ << "\", ignoring");
         }
     }
     catch ( const GenICam::GenericException &e )

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige_ace2.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige_ace2.hpp
@@ -103,7 +103,7 @@ bool PylonROS2GigEAce2Camera::applyCamSpecificStartupSettings(const PylonROS2Cam
         grabbingStarting();
         cam_->StopGrabbing();
 
-        RCLCPP_INFO_STREAM(LOGGER_GIGE_ACE2, "Startup user profile set to " << parameters.startup_user_set_);
+        RCLCPP_INFO_STREAM(LOGGER_GIGE_ACE2, "Startup user profile set to \"" << parameters.startup_user_set_ << "\"");
         if (parameters.startup_user_set_ == "Default")
         {
             // Remove all previous settings (sequencer etc.)
@@ -203,7 +203,7 @@ bool PylonROS2GigEAce2Camera::applyCamSpecificStartupSettings(const PylonROS2Cam
             // frame transmission delay
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
 
-            RCLCPP_WARN(LOGGER_GIGE_ACE2, "Default User Setting Loaded");
+            RCLCPP_INFO(LOGGER_GIGE_ACE2, "Default User Setting Loaded");
         }
         else if (parameters.startup_user_set_ == "UserSet1")
         {
@@ -213,8 +213,8 @@ bool PylonROS2GigEAce2Camera::applyCamSpecificStartupSettings(const PylonROS2Cam
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE_ACE2, "User Set 1 Loaded");
+
+            RCLCPP_INFO(LOGGER_GIGE_ACE2, "User Set 1 Loaded");
         }
         else if (parameters.startup_user_set_ == "UserSet2")
         {
@@ -224,8 +224,8 @@ bool PylonROS2GigEAce2Camera::applyCamSpecificStartupSettings(const PylonROS2Cam
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE_ACE2, "User Set 2 Loaded");
+
+            RCLCPP_INFO(LOGGER_GIGE_ACE2, "User Set 2 Loaded");
         }
         else if (parameters.startup_user_set_ == "UserSet3")
         {
@@ -235,16 +235,20 @@ bool PylonROS2GigEAce2Camera::applyCamSpecificStartupSettings(const PylonROS2Cam
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE_ACE2, "User Set 3 Loaded");
+
+            RCLCPP_INFO(LOGGER_GIGE_ACE2, "User Set 3 Loaded");
         }
         else if (parameters.startup_user_set_ == "CurrentSetting")
         {
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);
-            
-            RCLCPP_WARN(LOGGER_GIGE_ACE2, "No user set is provided -> Camera current setting will be applied");
+
+            RCLCPP_INFO(LOGGER_GIGE_ACE2, "No user set is provided -> Camera current setting will be applied");
+        }
+        else
+        {
+            RCLCPP_WARN_STREAM(LOGGER_GIGE_ACE2, "Unsupported startup user profile \"" << parameters.startup_user_set_ << "\", ignoring");
         }
     }
     catch ( const GenICam::GenericException &e )

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_usb.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_usb.hpp
@@ -94,7 +94,7 @@ bool PylonROS2USBCamera::applyCamSpecificStartupSettings(const PylonROS2CameraPa
         grabbingStarting();
         cam_->StopGrabbing();
 
-        RCLCPP_INFO_STREAM(LOGGER_USB, "Startup user profile set to " << parameters.startup_user_set_);
+        RCLCPP_INFO_STREAM(LOGGER_USB, "Startup user profile set to \"" << parameters.startup_user_set_ << "\"");
         if (parameters.startup_user_set_ == "Default")
         {
             // Remove all previous settings (sequencer etc.)
@@ -158,23 +158,27 @@ bool PylonROS2USBCamera::applyCamSpecificStartupSettings(const PylonROS2CameraPa
         {
             cam_->UserSetSelector.SetValue(Basler_UniversalCameraParams::UserSetSelector_UserSet1);
             cam_->UserSetLoad.Execute();
-            RCLCPP_WARN(LOGGER_USB, "User Set 1 Loaded");
+            RCLCPP_INFO(LOGGER_USB, "User Set 1 Loaded");
         }
         else if (parameters.startup_user_set_ == "UserSet2")
         {
             cam_->UserSetSelector.SetValue(Basler_UniversalCameraParams::UserSetSelector_UserSet2);
             cam_->UserSetLoad.Execute();
-            RCLCPP_WARN(LOGGER_USB, "User Set 2 Loaded");
+            RCLCPP_INFO(LOGGER_USB, "User Set 2 Loaded");
         }
         else if (parameters.startup_user_set_ == "UserSet3")
         {
             cam_->UserSetSelector.SetValue(Basler_UniversalCameraParams::UserSetSelector_UserSet3);
             cam_->UserSetLoad.Execute();
-            RCLCPP_WARN(LOGGER_USB, "User Set 3 Loaded");
+            RCLCPP_INFO(LOGGER_USB, "User Set 3 Loaded");
         }
         else if (parameters.startup_user_set_ == "CurrentSetting")
         {
-            RCLCPP_WARN(LOGGER_USB, "No user set is provided -> Camera current setting will be applied");
+            RCLCPP_INFO(LOGGER_USB, "No user set is provided -> Camera current setting will be applied");
+        }
+        else
+        {
+            RCLCPP_WARN_STREAM(LOGGER_USB, "Unsupported startup user profile \"" << parameters.startup_user_set_ << "\", ignoring");
         }
     }
     catch ( const GenICam::GenericException &e )


### PR DESCRIPTION
Warn if an unsupported startup profile is set by the user. Also, set the log level to INFO for the startup profile messages.