### PR TITLE
Fix image encoding parameter by declaring it

### DIFF
--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
@@ -169,23 +169,25 @@ void PylonROS2CameraParameter::readFromRosParameterServer(rclcpp::Node& nh)
     nh.get_parameter("downsampling_factor_exposure_search", this->downsampling_factor_exposure_search_);
 
     RCLCPP_DEBUG(LOGGER, "---> image_encoding");
-    if (nh.has_parameter("image_encoding"))
+    if (!nh.has_parameter("image_encoding"))
     {
-        std::string encoding;
-        nh.get_parameter("image_encoding", encoding);
-        if (!encoding.empty() &&
-            !sensor_msgs::image_encodings::isMono(encoding) &&
-            !sensor_msgs::image_encodings::isColor(encoding) &&
-            !sensor_msgs::image_encodings::isBayer(encoding) &&
-            encoding != sensor_msgs::image_encodings::YUV422)
-        {
-            RCLCPP_WARN_STREAM(LOGGER, "Desired image encoding parameter: '" << encoding
-                << "' is not part of the 'sensor_msgs/image_encodings.h' list!"
-                << " Will not set encoding");
-            encoding = std::string("");
-        }
-        this->image_encoding_ = encoding;
+        nh.declare_parameter<std::string>("image_encoding", "");
     }
+    std::string encoding;
+    nh.get_parameter("image_encoding", encoding);
+    if (!encoding.empty() &&
+    !sensor_msgs::image_encodings::isMono(encoding) &&
+    !sensor_msgs::image_encodings::isColor(encoding) &&
+    !sensor_msgs::image_encodings::isBayer(encoding) &&
+    encoding != sensor_msgs::image_encodings::YUV422)
+    {
+        RCLCPP_WARN_STREAM(LOGGER, "Desired image encoding parameter: '" << encoding
+        << "' is not part of the 'sensor_msgs/image_encodings.h' list!"
+        << " Will not set encoding");
+        encoding = std::string("");
+    }
+
+    this->image_encoding_ = encoding;
 
     // ##########################
     //  image intensity settings


### PR DESCRIPTION
When launching the Pylon ROS2 Camera Node Component, the image_encoding parameter is not read. Thus it will be automatically set to e.g. mono8. This is because in ROS2 we need to declare parameters before we use them.

The issue probably applies to other parameters as well (e.g. the binning_x and binning_y parameters), but I haven't fixed that as it is not relevant for us.