### PR TITLE
Fixed subscribers check when remapping Blaze topics and fixed large memory leak for every image

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_blaze.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_blaze.hpp
@@ -546,6 +546,7 @@ bool PylonROS2BlazeCamera::processAndConvertBlazeData(const Pylon::CPylonDataCon
     uint16_t* pdepth_data = new uint16_t[width * height];
     this->calculateDepthMap(range_component, min_depth, max_depth, pdepth_data);
     cv::Mat depth_map = cv::Mat(height, width, CV_16UC1, pdepth_data);
+    free(pdepth_data);
     // convert
     cv_bridge::CvImage depth_map_cv_img;
     depth_map_cv_img.encoding = sensor_msgs::image_encodings::MONO16;
@@ -563,6 +564,7 @@ bool PylonROS2BlazeCamera::processAndConvertBlazeData(const Pylon::CPylonDataCon
     BGR* pdepth_data_color = new BGR[width * height];
     this->calculateDepthMapColor(range_component, min_depth, max_depth, pdepth_data_color);
     cv::Mat depth_map_color = cv::Mat(height, width, CV_8UC3, pdepth_data_color);
+    free(pdepth_data_color);
     // convert
     cv_bridge::CvImage depth_map_color_cv_img;
     depth_map_color_cv_img.encoding = sensor_msgs::image_encodings::BGR8;

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -976,11 +976,11 @@ void PylonROS2CameraNode::spin()
   }
   else
   {
-    if (!this->isSleeping() && (this->count_subscribers(this->blaze_cloud_topic_name_) ||
-                                this->count_subscribers(this->blaze_intensity_topic_name_) ||
-                                this->count_subscribers(this->blaze_depth_map_topic_name_) ||
-                                this->count_subscribers(this->blaze_depth_map_color_topic_name_) ||
-                                this->count_subscribers(this->blaze_confidence_topic_name_)))
+    if (!this->isSleeping() && (this->blaze_cloud_pub_->get_subscription_count() ||
+                                this->blaze_intensity_pub_->get_subscription_count() ||
+                                this->blaze_depth_map_pub_->get_subscription_count() ||
+                                this->blaze_depth_map_color_pub_->get_subscription_count() ||
+                                this->blaze_cam_info_pub_->get_subscription_count()))
     {
       this->pylon_camera_->getInitialCameraInfo(this->blaze_cam_info_msg_);
 


### PR DESCRIPTION
Fixed subscribers check when remapping.

According to [this issue,](https://github.com/ros2/rclcpp/issues/1174) _count_subscribers_ does not respect remapping (anymore).