### PR TITLE
Fix resource leak with camera_info_manager

### DIFF
--- a/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
+++ b/pylon_camera/src/pylon_camera/pylon_camera_node.cpp
@@ -3517,6 +3517,12 @@ PylonCameraNode::~PylonCameraNode()
         delete pinhole_model_;
         pinhole_model_ = nullptr;
     }
+
+    if ( camera_info_manager_ )
+    {
+        delete camera_info_manager_;
+        camera_info_manager_ = nullptr;
+    }
 }
 
 }  // namespace pylon_camera


### PR DESCRIPTION
The ROS1 branch has a leak regarding camera_info_manager_ instance that is allocated on the heap but not deleted in destructor. This PR fixes that.