### PR TITLE
Fixes Build Errors for workspace setups with cv_bridge / image_geometry version >= 3.3.0

### DIFF
--- a/pylon_ros2_camera_component/CMakeLists.txt
+++ b/pylon_ros2_camera_component/CMakeLists.txt
@@ -56,6 +56,10 @@ find_package(image_geometry REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 
+if(cv_bridge_VERSION VERSION_GREATER_EQUAL 3.3.0)
+    add_compile_definitions(cv_bridge_HPP)
+endif()
+
 set(PYLON_ROS2_CAMERA_DEPENDENCIES
 	pylon_ros2_camera_interfaces
 	rclcpp

--- a/pylon_ros2_camera_component/CMakeLists.txt
+++ b/pylon_ros2_camera_component/CMakeLists.txt
@@ -59,6 +59,9 @@ find_package(diagnostic_updater REQUIRED)
 if(cv_bridge_VERSION VERSION_GREATER_EQUAL 3.3.0)
     add_compile_definitions(cv_bridge_HPP)
 endif()
+if(image_geometry_VERSION VERSION_GREATER_EQUAL 3.3.0)
+    add_compile_definitions(image_geometry_HPP)
+endif()
 
 set(PYLON_ROS2_CAMERA_DEPENDENCIES
 	pylon_ros2_camera_interfaces

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_blaze.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_blaze.hpp
@@ -35,7 +35,11 @@
 
 #include <pylon/BlazeInstantCamera.h>
 
+#ifdef cv_bridge_HPP
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 #include <opencv2/highgui/highgui.hpp>
 
 //#include <boost/make_shared.hpp>

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -74,7 +74,11 @@
 #include "pylon_ros2_camera_parameter.hpp"
 
 #include <camera_info_manager/camera_info_manager.hpp>
+#ifdef image_geometry_HPP
+#include <image_geometry/pinhole_camera_model.hpp>
+#else
 #include <image_geometry/pinhole_camera_model.h>
+#endif
 
 #ifdef cv_bridge_HPP
 #include <cv_bridge/cv_bridge.hpp>

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -76,7 +76,11 @@
 #include <camera_info_manager/camera_info_manager.hpp>
 #include <image_geometry/pinhole_camera_model.h>
 
+#ifdef cv_bridge_HPP
+#include <cv_bridge/cv_bridge.hpp>
+#else
 #include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <image_transport/image_transport.hpp>
 #include <image_transport/camera_publisher.hpp>

--- a/pylon_ros2_camera_wrapper/CMakeLists.txt
+++ b/pylon_ros2_camera_wrapper/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(pylon_ros2_camera_component REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(image_geometry REQUIRED)
 
 set(CAMERA_WRAPPER_DEPENDENCIES
 	rclcpp
@@ -47,7 +48,16 @@ set(CAMERA_WRAPPER_DEPENDENCIES
 	rcutils
 	pylon_ros2_camera_component
 	cv_bridge
+	image_geometry
 )
+# we need to add these two checks to use the correct headers
+if(cv_bridge_VERSION VERSION_GREATER_EQUAL 3.3.0)
+    add_compile_definitions(cv_bridge_HPP)
+endif()
+
+if(image_geometry_VERSION VERSION_GREATER_EQUAL 3.3.0)
+    add_compile_definitions(image_geometry_HPP)
+endif()
 
 add_executable(${PROJECT_NAME}
 	${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}.cpp

--- a/pylon_ros2_camera_wrapper/package.xml
+++ b/pylon_ros2_camera_wrapper/package.xml
@@ -3,26 +3,24 @@
 <package format="3">
 
   <name>pylon_ros2_camera_wrapper</name>
-
   <version>1.1.0</version>
 
-  <description> Wrapper loading pylon_ros2_camera component in a single process </description>
+  <description>
+    
+    Wrapper loading pylon_ros2_camera component in a single process 
+  </description>
 
   <maintainer email="fpi@teknologisk.dk">Francois Picard</maintainer>
-
   <license>BSD</license>
-
   <url type="website">https://www.baslerweb.com/en/</url>
   <url type="repository">https://github.com/basler/pylon-ros-camera</url>
   <url type="bugtracker">https://github.com/basler/pylon-ros-camera/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <build_depend>pylon_ros2_camera_component</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rcutils</build_depend>
-
   <exec_depend>pylon_ros2_camera_component</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
@@ -54,5 +52,4 @@
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-
 </package>

--- a/pylon_ros2_camera_wrapper/package.xml
+++ b/pylon_ros2_camera_wrapper/package.xml
@@ -3,28 +3,26 @@
 <package format="3">
 
   <name>pylon_ros2_camera_wrapper</name>
-  
+
   <version>1.1.0</version>
-  
-  <description>
-    Wrapper loading pylon_ros2_camera component in a single process
-  </description>
-    
+
+  <description> Wrapper loading pylon_ros2_camera component in a single process </description>
+
   <maintainer email="fpi@teknologisk.dk">Francois Picard</maintainer>
-  
+
   <license>BSD</license>
-  
+
   <url type="website">https://www.baslerweb.com/en/</url>
   <url type="repository">https://github.com/basler/pylon-ros-camera</url>
   <url type="bugtracker">https://github.com/basler/pylon-ros-camera/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
+
   <build_depend>pylon_ros2_camera_component</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rcutils</build_depend>
-  
+
   <exec_depend>pylon_ros2_camera_component</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
@@ -33,6 +31,8 @@
   <!-- For the tests -->
   <build_depend>cv_bridge</build_depend>
   <exec_depend>cv_bridge</exec_depend>
+  <build_depend>image_geometry</build_depend>
+  <exec_depend>image_geometry</exec_depend>
 
   <!-- The ability to run Python tests using pytest in the ament buildsystem in CMake. -->
   <test_depend>ament_cmake_pytest</test_depend>
@@ -54,5 +54,5 @@
   <export>
     <build_type>ament_cmake</build_type>
   </export>
-  
+
 </package>

--- a/pylon_ros2_camera_wrapper/package.xml
+++ b/pylon_ros2_camera_wrapper/package.xml
@@ -3,24 +3,28 @@
 <package format="3">
 
   <name>pylon_ros2_camera_wrapper</name>
+  
   <version>1.1.0</version>
-
+  
   <description>
-    
-    Wrapper loading pylon_ros2_camera component in a single process 
+    Wrapper loading pylon_ros2_camera component in a single process
   </description>
-
+    
   <maintainer email="fpi@teknologisk.dk">Francois Picard</maintainer>
+  
   <license>BSD</license>
+  
   <url type="website">https://www.baslerweb.com/en/</url>
   <url type="repository">https://github.com/basler/pylon-ros-camera</url>
   <url type="bugtracker">https://github.com/basler/pylon-ros-camera/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  
   <build_depend>pylon_ros2_camera_component</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rcutils</build_depend>
+  
   <exec_depend>pylon_ros2_camera_component</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
@@ -52,4 +56,5 @@
   <export>
     <build_type>ament_cmake</build_type>
   </export>
+  
 </package>


### PR DESCRIPTION
Hi,

I encountered some build errors in a workspace using more recent versions of the cv_bridge and image_geometry packages. In my particular case it was in a ROS2 Jazzy workspace, so maybe this pull request is not perfectly fitting for the humble branch.
Still the requested changes will allow backward-capabality for older versions of the packages. Please find information on the removed .h header files in the changelogs here:

https://github.com/ros-perception/vision_opencv/blob/rolling/image_geometry/CHANGELOG.rst#330-2022-09-14
https://github.com/ros-perception/vision_opencv/blob/rolling/cv_bridge/CHANGELOG.rst#330-2022-09-14