### PR TITLE
gige: set upper exposure also for current setting

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige.hpp
@@ -309,6 +309,20 @@ bool PylonROS2GigECamera::applyCamSpecificStartupSettings(const PylonROS2CameraP
         }
         else if (parameters.startup_user_set_ == "CurrentSetting")
         {
+
+            /* Thresholds for the AutoExposure Functions:
+                *  - lower limit can be used to get rid of changing light conditions
+                *    due to 50Hz lamps (-> 20ms cycle duration)
+                *  - upper limit is to prevent motion blur
+                */
+            double upper_lim = std::min(parameters.auto_exposure_upper_limit_, cam_->ExposureTimeAbs.GetMax());
+            cam_->AutoExposureTimeAbsLowerLimit.SetValue(cam_->ExposureTimeAbs.GetMin());
+            cam_->AutoExposureTimeAbsUpperLimit.SetValue(upper_lim);
+            RCLCPP_INFO_STREAM(LOGGER_GIGE, "Cam has upper exposure value limit range: ["
+                    << cam_->ExposureTimeAbs.GetMin()
+                    << " - " << upper_lim << " (max possible value from cam is " << cam_->ExposureTimeAbs.GetMax() << ")"
+                    << "].");
+            
             cam_->GevSCPSPacketSize.SetValue(parameters.mtu_size_);
             cam_->GevSCPD.SetValue(parameters.inter_pkg_delay_);
             cam_->GevSCFTD.SetValue(parameters.frame_transmission_delay_);


### PR DESCRIPTION
With this PR `auto_exposure_upper_limit` is taken into account not only when `startup_user_set` is set to `Default` but also when it is set to `CurrentSetting`.
I am not sure what was the reason for not allowing changing `auto_exposure_upper_limit` when using `CurrentSetting` and I could not find a good reason for this from the pylon API documentation. 
I tested it with our cameras, where we need to use `CurrentSetting` but still set `auto_exposure_upper_limit`, and it works well.

Note: I only changed the code for the `gige` camera type. I am not sure if this would also work for the other types.