### PR TITLE
Humble compatibility: lower cmake_minimum_required to 3.22 for pylon_ros_camera_interfaces

### DIFF
--- a/pylon_ros2_camera_interfaces/CMakeLists.txt
+++ b/pylon_ros2_camera_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.22)
 
 project(pylon_ros2_camera_interfaces)
 


### PR DESCRIPTION
lower the cmake 3.27 requirements to 3.22 to not interfere with the current ROS Humble distribution setup