### PR TITLE
Various performance optimizations

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -430,14 +430,11 @@ bool PylonROS2CameraImpl<CameraTrait>::grab(std::vector<uint8_t>& image, rclcpp:
     
     const uint8_t *pImageBuffer = reinterpret_cast<uint8_t*>(ptr_grab_result->GetBuffer());
 
-    // ------------------------------------------------------------------------
-    // Bit shifting
-    // ------------------------------------------------------------------------
-    // In case of 12 bits we need to shift the image bits 4 positions to the left
-    const std::string ros_enc = this->currentROSEncoding();
-    const std::string gen_api_encoding(cam_->PixelFormat.ToString().c_str());
-    if (encodingconversions::is_12_bit_ros_enc(ros_enc) && (gen_api_encoding == "BayerRG12" || gen_api_encoding == "BayerBG12" || gen_api_encoding == "BayerGB12" || gen_api_encoding == "BayerGR12" || gen_api_encoding == "Mono12"))
-    {
+    if (this->bit_shift_active_){
+        // ------------------------------------------------------------------------
+        // Bit shifting
+        // ------------------------------------------------------------------------
+        // In case of 12 bits we need to shift the image bits 4 positions to the left
         std::vector<uint16_t> shift_array(img_size_byte_ / 2); // Dynamically allocated to avoid heap size error
         const uint16_t *convert_bits = reinterpret_cast<uint16_t*>(ptr_grab_result->GetBuffer());
         for (size_t i = 0; i < img_size_byte_ / 2; i++)
@@ -451,32 +448,32 @@ bool PylonROS2CameraImpl<CameraTrait>::grab(std::vector<uint8_t>& image, rclcpp:
         image.assign(pImageBuffer, pImageBuffer + img_size_byte_);
     }
 
-    bool use_chunk_timestamp = false;
-    if (this->getChunkModeActive() == 1)
+    if (this->chunk_mode_active_)
     {
+        bool use_chunk_timestamp = false;
         const std::string success = this->setChunkSelector(29); // = ChunkSelector_Timestamp
         if (success.find("done") != std::string::npos && this->getChunkEnable() == 1)
         {
             use_chunk_timestamp = true;
         }
-    }
 
-    if (use_chunk_timestamp)
-    {
-        try
+        if (use_chunk_timestamp)
         {
-            if (!ptr_grab_result->ChunkTimestamp.IsReadable())
+            try
             {
-                RCLCPP_WARN_STREAM(LOGGER_BASE, "Error while trying to get the chunk timestamp. The connected camera may not support this feature");
+                if (!ptr_grab_result->ChunkTimestamp.IsReadable())
+                {
+                    RCLCPP_WARN_STREAM(LOGGER_BASE, "Error while trying to get the chunk timestamp. The connected camera may not support this feature");
+                }
+                else
+                {
+                    stamp = rclcpp::Time(static_cast<uint64_t>(ptr_grab_result->ChunkTimestamp.GetValue()));
+                }
             }
-            else
+            catch (const GenICam::GenericException &e)
             {
-                stamp = rclcpp::Time(static_cast<uint64_t>(ptr_grab_result->ChunkTimestamp.GetValue()));
+                RCLCPP_WARN_STREAM(LOGGER_BASE, "An exception while getting the chunk timestamp occurred: " << e.GetDescription());
             }
-        }
-        catch (const GenICam::GenericException &e)
-        {
-            RCLCPP_WARN_STREAM(LOGGER_BASE, "An exception while getting the chunk timestamp occurred: " << e.GetDescription());
         }
     }
 

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -581,6 +581,10 @@ bool PylonROS2CameraImpl<CameraTrait>::grab(Pylon::CBaslerUniversalGrabResultPtr
         if (cam_->IsCameraDeviceRemoved())
         {
             RCLCPP_ERROR(LOGGER_BASE, "Lost connection to the camera . . .");
+            cam_->StopGrabbing();
+            RCLCPP_ERROR(LOGGER_BASE, "Reconnect the camera and restart the node!");
+            rclcpp::shutdown();
+            exit(1);
         }
         else
         {

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera.hpp
@@ -1261,6 +1261,12 @@ public:
 
     virtual ~PylonROS2Camera();
 
+    /**
+     * Internal attributes
+     */
+    bool chunk_mode_active_{false};
+    bool bit_shift_active_{false};
+
 protected:
     /**
      * Protected default constructor.

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -32,6 +32,7 @@
 
 //#include <functional>
 
+#include "encoding_conversions.hpp"
 #include "pylon_ros2_camera_node.hpp"
 
 
@@ -133,6 +134,20 @@ bool PylonROS2CameraNode::init()
     RCLCPP_ERROR(LOGGER, "Error when trying to init and register. Shutting down now.");
     rclcpp::shutdown();
     return false;
+  }
+
+  // set grabbed image conversion parameters
+  if (this->pylon_camera_->getChunkModeActive() == 1)
+  {
+    RCLCPP_INFO(LOGGER, "Activated chunk mode");
+    this->pylon_camera_->chunk_mode_active_ = true;
+  }
+  const std::string ros_enc = this->pylon_camera_->currentROSEncoding();
+  const std::string gen_api_encoding(this->pylon_camera_->currentBaslerEncoding());
+  if (encodingconversions::is_12_bit_ros_enc(ros_enc) && (gen_api_encoding == "BayerRG12" || gen_api_encoding == "BayerBG12" || gen_api_encoding == "BayerGB12" || gen_api_encoding == "BayerGR12" || gen_api_encoding == "Mono12"))
+  {
+    RCLCPP_INFO(LOGGER, "Activated bit shifting");
+    this->pylon_camera_->bit_shift_active_ = true;
   }
 
   // starting the grabbing procedure with the desired image-settings

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -918,37 +918,6 @@ void PylonROS2CameraNode::spin()
     double start_time = rclcpp::Clock().now().seconds();
     double tdiff; // used to compute time difference during the grabbing process
 
-    // check if the camera is disconnected
-    // the call time cost to isCamRemoved() is unsignificant with respect to the grabbing frame rate
-    if (this->pylon_camera_->isCamRemoved())
-    {
-      RCLCPP_ERROR(LOGGER, "Camera is disconnected, trying now to reconnect");
-
-      this->cm_status_.status_id = pylon_ros2_camera_interfaces::msg::ComponentStatus::ERROR;
-      this->cm_status_.status_msg = "Camera is disconnected, trying now to reconnect";
-
-      if (this->pylon_camera_parameter_set_.enable_status_publisher_)
-      {
-        this->component_status_pub_->publish(this->cm_status_);
-      }
-
-      if (this->pylon_camera_ != nullptr)
-      {
-        this->pylon_camera_.reset();
-      }
-
-      // Possible issue here: ROS2 does not allow to shutdown services
-      // Services are shutdown in the ROS 1 pylon version at this level
-      this->set_user_output_srvs_.clear();
-
-      rclcpp::Rate r(0.5);
-      r.sleep();
-
-      this->init();
-
-      continue;
-    }
-
     // grab
     RCLCPP_DEBUG(LOGGER, ">>> New frame grabbing <<<");
 

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -1025,14 +1025,6 @@ void PylonROS2CameraNode::spin()
       }
     }
 
-    // Check if the image encoding changed , then save the new image encoding and restart the image grabbing to fix the ros sensor message type issue.
-    if (this->pylon_camera_parameter_set_.imageEncoding() != this->pylon_camera_->currentROSEncoding()) 
-    {
-      this->pylon_camera_parameter_set_.setimageEncodingParam(*this, this->pylon_camera_->currentROSEncoding());
-      this->grabbingStopping();
-      this->grabbingStarting();
-    }
-    
     if (this->pylon_camera_parameter_set_.enable_status_publisher_)
     {
       this->component_status_pub_->publish(this->cm_status_);

--- a/pylon_ros2_camera_wrapper/launch/pylon_ros2_camera.launch.py
+++ b/pylon_ros2_camera_wrapper/launch/pylon_ros2_camera.launch.py
@@ -108,13 +108,13 @@ def generate_launch_description():
 
     declare_enable_status_publisher_cmd = DeclareLaunchArgument(
         'enable_status_publisher',
-        default_value='true',
+        default_value='false',
         description='Enable/Disable the status publishing.'
     )
 
     declare_enable_current_params_publisher_cmd = DeclareLaunchArgument(
         'enable_current_params_publisher',
-        default_value='true',
+        default_value='false',
         description='Enable/Disable the current parameter publishing.'
     )
 


### PR DESCRIPTION
This is a follow up of https://github.com/basler/pylon-ros-camera/pull/262, but now for the current jazzy branch version.

- Even though it is stated in the readme, the status publishers are not disabled by default (or only somewhere else).
- The check for the removed camera took 1.05ms in my renewed tests. How did you measure the "unsignificant" in the comment? I have measured my time here with the sync offset (https://github.com/basler/pylon-ros-camera/pull/286), because the check happens before grabbing, the header timestamps were 1ms off. It is not detectable in the _ros2 topic delay_, because it is not in the image grabbing process, but might result in a trigger slowdown at high frame rates.
- I don't have a value for the encoding changes this time, because it is just reducing the sleep duration.
- The optimized postprocessing gave me 1.3ms speedup.

Regarding the discussion in the old PR:
- Removing the camera and plugging it in again still does not work for me (using docker + usb camera). Has this been tested? I also think the trade-off between this (rarely used?) functionality and the performance improvement is better for the second option.
- Is changing the chunk mode and the encoding at runtime a frequent use-case? And if it really is, maybe an alternative option could be to call these functions only once after a change (using some boolean flag) and not every frame.

Feel free to ask any questions you have, or cherry-picking any single commits.