### PR TITLE
Masking out image parts

### DIFF
--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -1828,6 +1828,9 @@ protected:
   // mutex
   std::recursive_mutex grab_mutex_;
 
+  // mask regions
+  std::vector<std::array<int, 4>> mask_regions_;
+
   // intern
   std::vector<std::size_t> sampling_indices_;
   std::array<float, 256> brightness_exp_lut_{};

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_parameter.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_parameter.hpp
@@ -334,6 +334,11 @@ public:
     */
     int grab_strategy_;
 
+    /**
+     * Mask regions stored as arrays [x_start, y_start, x_end, y_end]
+     * For some reason using a vector of arrays did not work
+     */
+    std::string mask_points_;
 
 protected:
     /**

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -31,6 +31,7 @@
 #include <rclcpp/logger.hpp>
 
 //#include <functional>
+#include <regex>
 
 #include "pylon_ros2_camera_node.hpp"
 
@@ -72,6 +73,39 @@ PylonROS2CameraNode::PylonROS2CameraNode(const rclcpp::NodeOptions& options)
   // initialize camera instance and start grabbing
   if (!this->init())
     return;
+
+  // parse mask points with json format of "[[x_start, y_start, x_end, y_end], ...]"
+  // to a simpler format of "x_start,y_start,x_end,y_end, ..."
+  std::regex outerRegex(R"((\[[\d+, ]+\]))");
+  std::regex innerRegex(R"(\[(-?\d+),\s*(-?\d+),\s*(-?\d+),\s*(-?\d+)\])");
+  std::smatch outerMatch;
+  std::string s = this->pylon_camera_parameter_set_.mask_points_;
+  std::vector<std::array<int, 4>> mask_regions;
+  while (std::regex_search(s, outerMatch, outerRegex)) 
+  {
+      std::string sublistStr = outerMatch[1].str();
+      std::smatch innerMatch;
+
+      if (std::regex_match(sublistStr, innerMatch, innerRegex)) {
+          std::array<int, 4> arr = {
+              std::stoi(innerMatch[1].str()), 
+              std::stoi(innerMatch[2].str()), 
+              std::stoi(innerMatch[3].str()), 
+              std::stoi(innerMatch[4].str())
+          };
+          mask_regions.push_back(arr);
+      }
+      s = outerMatch.suffix().str();
+  }
+  std::string mask_str = "";
+  for (const auto& region : mask_regions) {
+      mask_str += std::to_string(region[0]) + "," + std::to_string(region[1]) + "," + std::to_string(region[2]) + "," + std::to_string(region[3]) + ",";
+  }
+  if (!mask_str.empty()) {
+      mask_str = mask_str.substr(0, mask_str.size() - 1);
+  }
+  this->pylon_camera_parameter_set_.mask_points_ = mask_str;
+  RCLCPP_INFO(LOGGER, "Parsed masks: '%s'", this->pylon_camera_parameter_set_.mask_points_.c_str());
 
   // starting spinning thread
   RCLCPP_INFO_STREAM(LOGGER, "Start image grabbing if node connects to topic with a spinning rate of: " << this->frameRate() << " Hz");
@@ -1111,6 +1145,48 @@ bool PylonROS2CameraNode::grabImage()
       return false;
     }
     this->img_raw_msg_.header.stamp = stamp;
+
+    // apply mask if available
+    if (this->pylon_camera_parameter_set_.mask_points_ != "")
+    {
+
+      // extract the coordinates from the input string
+      std::vector<std::array<int, 4>> mask_regions;
+      std::stringstream ss(this->pylon_camera_parameter_set_.mask_points_);
+      std::string token;
+      std::array<int, 4> currentRegion;
+      size_t idx = 0;
+      while (std::getline(ss, token, ','))
+      {
+        currentRegion[idx] = std::stoi(token);
+        ++idx;
+        if (idx == 4)
+        {
+          mask_regions.push_back(currentRegion);
+          idx = 0;
+        }
+      }
+
+      // get the number of bytes per pixel
+      int bytes_per_pixel = sensor_msgs::image_encodings::bitDepth(this->img_raw_msg_.encoding) / 8;
+
+      // apply masks by setting pixels in the region to zero
+      for (const auto &region : mask_regions)
+      {
+        // Ensure bounds are within image dimensions
+        int min_x = std::max(0, region[0]);
+        int min_y = std::max(0, region[1]);
+        int max_x = std::min(static_cast<int>(this->img_raw_msg_.width) - 1, region[2]);
+        int max_y = std::min(static_cast<int>(this->img_raw_msg_.height) - 1, region[3]);
+
+        // Apply mask by setting pixels to zero using memset
+        for (int y = min_y; y <= max_y; y++)
+        {
+          uint8_t *ptr = &this->img_raw_msg_.data[y * this->img_raw_msg_.step + min_x * bytes_per_pixel];
+          memset(ptr, 0, (max_x - min_x + 1) * bytes_per_pixel);
+        }
+      }
+    }
   }
   else
   {

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -75,37 +75,34 @@ PylonROS2CameraNode::PylonROS2CameraNode(const rclcpp::NodeOptions& options)
     return;
 
   // parse mask points with json format of "[[x_start, y_start, x_end, y_end], ...]"
-  // to a simpler format of "x_start,y_start,x_end,y_end, ..."
   std::regex outerRegex(R"((\[[\d+, ]+\]))");
   std::regex innerRegex(R"(\[(-?\d+),\s*(-?\d+),\s*(-?\d+),\s*(-?\d+)\])");
-  std::smatch outerMatch;
+  std::smatch outerMatch, innerMatch;
   std::string s = this->pylon_camera_parameter_set_.mask_points_;
-  std::vector<std::array<int, 4>> mask_regions;
-  while (std::regex_search(s, outerMatch, outerRegex)) 
+  while (std::regex_search(s, outerMatch, outerRegex))
   {
-      std::string sublistStr = outerMatch[1].str();
-      std::smatch innerMatch;
-
-      if (std::regex_match(sublistStr, innerMatch, innerRegex)) {
-          std::array<int, 4> arr = {
-              std::stoi(innerMatch[1].str()), 
-              std::stoi(innerMatch[2].str()), 
-              std::stoi(innerMatch[3].str()), 
-              std::stoi(innerMatch[4].str())
-          };
-          mask_regions.push_back(arr);
-      }
-      s = outerMatch.suffix().str();
+    std::string sublistStr = outerMatch[1].str();
+    if (std::regex_match(sublistStr, innerMatch, innerRegex))
+    {
+      std::array<int, 4> arr = {
+          std::stoi(innerMatch[1].str()),
+          std::stoi(innerMatch[2].str()),
+          std::stoi(innerMatch[3].str()),
+          std::stoi(innerMatch[4].str())};
+      mask_regions_.push_back(arr);
+    }
+    s = outerMatch.suffix().str();
   }
   std::string mask_str = "";
-  for (const auto& region : mask_regions) {
-      mask_str += std::to_string(region[0]) + "," + std::to_string(region[1]) + "," + std::to_string(region[2]) + "," + std::to_string(region[3]) + ",";
+  for (const auto &region : mask_regions_)
+  {
+    mask_str += "[" + std::to_string(region[0]) + "," + std::to_string(region[1]) + "," + std::to_string(region[2]) + "," + std::to_string(region[3]) + "],";
   }
-  if (!mask_str.empty()) {
-      mask_str = mask_str.substr(0, mask_str.size() - 1);
+  if (!mask_str.empty())
+  {
+    mask_str = mask_str.substr(0, mask_str.size() - 1);
   }
-  this->pylon_camera_parameter_set_.mask_points_ = mask_str;
-  RCLCPP_INFO(LOGGER, "Parsed masks: '%s'", this->pylon_camera_parameter_set_.mask_points_.c_str());
+  RCLCPP_INFO(LOGGER, "Parsed masks: '%s'", mask_str.c_str());
 
   // starting spinning thread
   RCLCPP_INFO_STREAM(LOGGER, "Start image grabbing if node connects to topic with a spinning rate of: " << this->frameRate() << " Hz");
@@ -1146,40 +1143,19 @@ bool PylonROS2CameraNode::grabImage()
     }
     this->img_raw_msg_.header.stamp = stamp;
 
-    // apply mask if available
     if (this->pylon_camera_parameter_set_.mask_points_ != "")
     {
-
-      // extract the coordinates from the input string
-      std::vector<std::array<int, 4>> mask_regions;
-      std::stringstream ss(this->pylon_camera_parameter_set_.mask_points_);
-      std::string token;
-      std::array<int, 4> currentRegion;
-      size_t idx = 0;
-      while (std::getline(ss, token, ','))
-      {
-        currentRegion[idx] = std::stoi(token);
-        ++idx;
-        if (idx == 4)
-        {
-          mask_regions.push_back(currentRegion);
-          idx = 0;
-        }
-      }
-
-      // get the number of bytes per pixel
+      // apply image masks by setting pixels in the region to zero
       int bytes_per_pixel = sensor_msgs::image_encodings::bitDepth(this->img_raw_msg_.encoding) / 8;
-
-      // apply masks by setting pixels in the region to zero
-      for (const auto &region : mask_regions)
+      for (const auto &region : mask_regions_)
       {
-        // Ensure bounds are within image dimensions
+        // ensure bounds are within image dimensions
         int min_x = std::max(0, region[0]);
         int min_y = std::max(0, region[1]);
         int max_x = std::min(static_cast<int>(this->img_raw_msg_.width) - 1, region[2]);
         int max_y = std::min(static_cast<int>(this->img_raw_msg_.height) - 1, region[3]);
 
-        // Apply mask by setting pixels to zero using memset
+        // set pixels to zero
         for (int y = min_y; y <= max_y; y++)
         {
           uint8_t *ptr = &this->img_raw_msg_.data[y * this->img_raw_msg_.step + min_x * bytes_per_pixel];

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
@@ -74,6 +74,7 @@ PylonROS2CameraParameter::PylonROS2CameraParameter() :
     white_balance_ratio_green_(1.0),
     white_balance_ratio_blue_(1.0),
     grab_strategy_(0),
+    mask_points_(""),
     camera_frame_("pylon_camera"),
     device_user_id_(""),
     frame_rate_(5.0),
@@ -530,6 +531,16 @@ void PylonROS2CameraParameter::readFromRosParameterServer(rclcpp::Node& nh)
     }
     
     nh.get_parameter("grab_strategy", this->grab_strategy_);
+
+    // mask_points
+    RCLCPP_DEBUG(LOGGER, "---> mask_points");
+
+    if (!nh.has_parameter("mask_points"))
+    {
+        nh.declare_parameter<std::string>("mask_points", "");
+    }
+    
+    nh.get_parameter("mask_points", this->mask_points_);
 
     // validating parameters
     this->validateParameterSet(nh);

--- a/pylon_ros2_camera_wrapper/config/default.yaml
+++ b/pylon_ros2_camera_wrapper/config/default.yaml
@@ -42,6 +42,10 @@
     #  Default value is "" (empty) means default_shutter_mode
     # shutter_mode: ""
 
+    # Mask regions in the image which are replaced with a black box
+    # Format as json string: [[x1_start, y1_start, x1_end, y1_end], ...]
+    # mask_points: '[[100, 100, 200, 250], [400, 400, 700, 800]]'
+
     ##########################################################################
     ######################## Image Intensity Settings ########################
     ##########################################################################


### PR DESCRIPTION
Adds an option that allows masking out parts of the image (to black boxes).
It's a bit similar to ROIs but allows using multiple negative masks.

My usecase is privacy related, I want to observe a larger space with the camera, but in one edge of the image persons are frequently passing by who I don't want to record and evaluate. Since I stream the images into the network, I wanted to remove this information already beforehand in the camera nodes.

But if you think it doesn't match well into the current feature set, you can also close this PR again.

