### PR TITLE
Add automatic camera reconnection on consecutive grab timeouts

### DIFF
--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_node.hpp
@@ -1834,6 +1834,9 @@ protected:
 
   bool is_sleeping_{false};
 
+  // consecutive grab failure counter for reconnection logic
+  int consecutive_grab_failures_{0};
+
   // diagnostics
   diagnostic_updater::Updater diagnostics_updater_;
 };

--- a/pylon_ros2_camera_component/include/pylon_ros2_camera_parameter.hpp
+++ b/pylon_ros2_camera_component/include/pylon_ros2_camera_parameter.hpp
@@ -327,7 +327,14 @@ public:
     float white_balance_ratio_blue_;
 
     /**
-    * Camera grab strategy 
+    * Maximum number of consecutive grab failures before triggering
+    * a camera reconnection. Set to 0 to disable this feature.
+    * Default: 100 (~50s at 500ms grab timeout)
+    */
+    int max_consecutive_grab_failures_;
+
+    /**
+    * Camera grab strategy
     * 0 = GrabStrategy_OneByOne
     * 1 = GrabStrategy_LatestImageOnly
     * 2 = GrabStrategy_LatestImages

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -961,8 +961,40 @@ void PylonROS2CameraNode::spin()
       {
         if (!this->grabImage())
         {
+          this->consecutive_grab_failures_++;
+
+          const int max_failures = this->pylon_camera_parameter_set_.max_consecutive_grab_failures_;
+          if (max_failures > 0 && this->consecutive_grab_failures_ >= max_failures)
+          {
+            RCLCPP_ERROR(LOGGER, "Reached %d consecutive grab failures, triggering camera reconnection", this->consecutive_grab_failures_);
+
+            this->cm_status_.status_id = pylon_ros2_camera_interfaces::msg::ComponentStatus::ERROR;
+            this->cm_status_.status_msg = "Too many consecutive grab failures, reconnecting";
+
+            if (this->pylon_camera_parameter_set_.enable_status_publisher_)
+            {
+              this->component_status_pub_->publish(this->cm_status_);
+            }
+
+            this->consecutive_grab_failures_ = 0;
+
+            if (this->pylon_camera_ != nullptr)
+            {
+              this->pylon_camera_.reset();
+            }
+
+            this->set_user_output_srvs_.clear();
+
+            rclcpp::Rate r(0.5);
+            r.sleep();
+
+            this->init();
+          }
+
           continue;
         }
+
+        this->consecutive_grab_failures_ = 0;
       }
 
       // compute grab time
@@ -1029,8 +1061,40 @@ void PylonROS2CameraNode::spin()
 
         if (!this->grabImage())
         {
+          this->consecutive_grab_failures_++;
+
+          const int max_failures = this->pylon_camera_parameter_set_.max_consecutive_grab_failures_;
+          if (max_failures > 0 && this->consecutive_grab_failures_ >= max_failures)
+          {
+            RCLCPP_ERROR(LOGGER, "Reached %d consecutive grab failures, triggering camera reconnection", this->consecutive_grab_failures_);
+
+            this->cm_status_.status_id = pylon_ros2_camera_interfaces::msg::ComponentStatus::ERROR;
+            this->cm_status_.status_msg = "Too many consecutive grab failures, reconnecting";
+
+            if (this->pylon_camera_parameter_set_.enable_status_publisher_)
+            {
+              this->component_status_pub_->publish(this->cm_status_);
+            }
+
+            this->consecutive_grab_failures_ = 0;
+
+            if (this->pylon_camera_ != nullptr)
+            {
+              this->pylon_camera_.reset();
+            }
+
+            this->set_user_output_srvs_.clear();
+
+            rclcpp::Rate r(0.5);
+            r.sleep();
+
+            this->init();
+          }
+
           continue;
         }
+
+        this->consecutive_grab_failures_ = 0;
 
         // compute grab time
         double grab_time = rclcpp::Clock().now().seconds();

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_parameter.cpp
@@ -68,6 +68,7 @@ PylonROS2CameraParameter::PylonROS2CameraParameter() :
     auto_flash_line_2_(true),
     auto_flash_line_3_(true),
     grab_timeout_(500),
+    max_consecutive_grab_failures_(100),
     trigger_timeout_(5000),
     white_balance_auto_(0),
     white_balance_ratio_red_(1.0),
@@ -470,6 +471,16 @@ void PylonROS2CameraParameter::readFromRosParameterServer(rclcpp::Node& nh)
     }
     
     nh.get_parameter("grab_timeout", this->grab_timeout_);
+
+    // max_consecutive_grab_failures
+    RCLCPP_DEBUG(LOGGER, "---> max_consecutive_grab_failures");
+
+    if (!nh.has_parameter("max_consecutive_grab_failures"))
+    {
+        nh.declare_parameter<int>("max_consecutive_grab_failures", 100);
+    }
+
+    nh.get_parameter("max_consecutive_grab_failures", this->max_consecutive_grab_failures_);
 
     // trigger_timeout
     RCLCPP_DEBUG(LOGGER, "---> trigger_timeout");


### PR DESCRIPTION
When a GigE transport failure causes continuous grab timeouts, the node would previously loop forever retrying grabs without attempting to reconnect. This adds a configurable max_consecutive_grab_failures parameter (default: 100) that triggers a full camera reinitialization after the threshold is reached, using the same recovery procedure as the existing isCamRemoved() path.