### PR TITLE
Fix camera_info to include real ROI on camera

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -687,8 +687,7 @@ void PylonROS2CameraImpl<CameraTraitT>::getInitialCameraInfo(sensor_msgs::msg::C
     // the same window of pixels on the camera sensor, regardless of binning
     // settings. The default setting of roi (all values 0) is considered the same
     // as full resolution (roi.width = width, roi.height = height).
-    cam_info_msg.roi.x_offset = cam_info_msg.roi.y_offset = 0;
-    cam_info_msg.roi.height = cam_info_msg.roi.width = 0;
+    cam_info_msg.roi = this->currentROI();
 }
 
 template <typename CameraTraitT>

--- a/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
+++ b/pylon_ros2_camera_component/src/pylon_ros2_camera_node.cpp
@@ -761,9 +761,10 @@ bool PylonROS2CameraNode::startGrabbing()
       if (this->camera_info_manager_->loadCameraInfo(this->pylon_camera_parameter_set_.cameraInfoURL()))
       {
         this->setupRectification();
-        // set the correct tf frame_id
+        // set the correct tf frame_id and current ROI from camera
         sensor_msgs::msg::CameraInfo cam_info = this->camera_info_manager_->getCameraInfo();
         cam_info.header.frame_id = this->img_raw_msg_.header.frame_id;
+        cam_info.roi = this->pylon_camera_->currentROI();
         this->camera_info_manager_->setCameraInfo(cam_info);
       }
       else


### PR DESCRIPTION
In the repo, currently the ROI is hardwired to zeros in the camera_info message. This patch reads the current settings in to construct the roi, so that calibration tools work with cropped images.