### PR TITLE
Remove gige namespace for mtu_size parameter in launch file.

### DIFF
--- a/pylon_ros2_camera_wrapper/launch/pylon_ros2_camera.launch.py
+++ b/pylon_ros2_camera_wrapper/launch/pylon_ros2_camera.launch.py
@@ -16,7 +16,7 @@ def _launch_node(context: LaunchContext):
     """Return the action to launch `pylon_ros2_camera_wrapper`.
     This is required to evaluate `respawn` as boolean.
     """
-    
+
     # adapt if needed
     debug = False
 
@@ -57,7 +57,7 @@ def _launch_node(context: LaunchContext):
                 parameters=[
                     config_file,
                     {
-                        'gige/mtu_size': mtu_size,
+                        'mtu_size': mtu_size,
                         'startup_user_set': startup_user_set,
                         'enable_status_publisher': enable_status_publisher,
                         'enable_current_params_publisher': enable_current_params_publisher


### PR DESCRIPTION
According to a [comment here](https://github.com/basler/pylon-ros-camera/issues/282#issuecomment-3642021474) `gige` prefix has been removed, however it's still present in the launch file which results in `mtu_size` argument to not be properly passed and later ignored. This PR fixes that.