### PR TITLE
Fix error in ace2 brightness logging

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige_ace2.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige_ace2.hpp
@@ -165,12 +165,24 @@ bool PylonROS2GigEAce2Camera::applyCamSpecificStartupSettings(const PylonROS2Cam
                     << cam_->Gamma.GetMax() << "].");
             }
 
-            // The gain auto function and the exposure auto function can be used at the
-            // same time. In this case, however, you must also set the Auto Function Profile feature.
-            RCLCPP_INFO_STREAM(LOGGER_GIGE_ACE2, "Cam has pylon auto brightness range: ["
-                << cam_->AutoTargetValue.GetMin() << " - "
-                << cam_->AutoTargetValue.GetMax()
-                << "] which is the average pixel intensity.");
+            // Check if auto brightness is available, print range
+            if (GenApi::IsAvailable(cam_->AutoTargetValue))
+            {
+                RCLCPP_INFO_STREAM(LOGGER_GIGE_ACE2, "Cam has pylon auto brightness range: ["
+                    << cam_->AutoTargetValue.GetMin() << " - "
+                    << cam_->AutoTargetValue.GetMax()
+                    << "] which is the average pixel intensity.");
+            }
+            else if (GenApi::IsAvailable(cam_->AutoTargetBrightness))
+            {
+                RCLCPP_INFO_STREAM(LOGGER_GIGE_ACE2, "Cam has pylon auto brightness range: ["
+                    << cam_->AutoTargetBrightness.GetMin() << " - "
+                    << cam_->AutoTargetBrightness.GetMax()
+                    << "] which is the average pixel intensity.");
+            } else {
+                RCLCPP_WARN(LOGGER_GIGE_ACE2, "Cam auto brightness not available, will keep the default (auto).");
+            }
+
 
             if ( GenApi::IsAvailable(cam_->BinningHorizontal) &&
                     GenApi::IsAvailable(cam_->BinningVertical) )


### PR DESCRIPTION
When using `Default` user_startup_set, AutoTargetValue is not available for ace2. This PR applies similar code as in the gige header to the ace2 header