### PR TITLE
Add brightness unit autodetection

### DIFF
--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_base.hpp
@@ -1201,6 +1201,24 @@ bool PylonROS2CameraImpl<CameraTraitT>::setGain(const float& target_gain,
 }
 
 template <typename CameraTraitT>
+double PylonROS2CameraImpl<CameraTraitT>::convertBrightness(const int& value)
+{
+    // The AutoTargetValue node (GigE ace 1) expects the absolute pixel intensity (0-255),
+    // whereas the AutoTargetBrightness node (USB, GigE ace 2) expects a normalized
+    // brightness in the range 0.0 (black) to 1.0 (white).
+    if ( GenApi::IsAvailable(cam_->AutoTargetValue) )
+    {
+        return value;
+    }
+    else if ( GenApi::IsAvailable(cam_->AutoTargetBrightness) )
+    {
+        return value / 255.0;
+    }
+    // In the unknown case, pass the value through unchanged
+    return value;
+}
+
+template <typename CameraTraitT>
 bool PylonROS2CameraImpl<CameraTraitT>::setBrightness(const int& target_brightness,
                                                   const float& current_brightness,
                                                   const bool& exposure_auto,
@@ -1211,8 +1229,8 @@ bool PylonROS2CameraImpl<CameraTraitT>::setBrightness(const int& target_brightne
         // if the target brightness is greater 255, limit it to 255
         // the brightness_to_set is a float value, regardless of the current
         // pixel data output format, i.e., 0.0 -> black, 1.0 -> white.
-        typename CameraTraitT::AutoTargetBrightnessValueType brightness_to_set =
-            CameraTraitT::convertBrightness(std::min(255, target_brightness));
+        double brightness_to_set =
+            convertBrightness(std::min(255, target_brightness));
 /**
 #if DEBUG
         std::cout << "br = " << current_brightness << ", gain = "
@@ -1344,7 +1362,7 @@ bool PylonROS2CameraImpl<CameraTraitT>::setBrightness(const int& target_brightne
     {
         RCLCPP_ERROR_STREAM(LOGGER_BASE, "An generic exception while setting target brightness to "
                 << target_brightness << " (= "
-                << CameraTraitT::convertBrightness(std::min(255, target_brightness))
+                << convertBrightness(std::min(255, target_brightness))
                 <<  ") occurred: " << e.GetDescription());
         return false;
     }
@@ -1375,8 +1393,8 @@ bool PylonROS2CameraImpl<CameraTraitT>::setExtendedBrightness(const int& target_
         return false;
     }
 
-    typename CameraTraitT::AutoTargetBrightnessValueType brightness_to_set =
-        CameraTraitT::convertBrightness(target_brightness);
+    double brightness_to_set =
+        convertBrightness(target_brightness);
 
     if ( !binary_exp_search_ )
     {

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_gige.hpp
@@ -59,7 +59,6 @@ struct GigECameraTrait
     // Therefore now both of them will use floats and convert at the end to integer when necessary
     typedef GenApi::IInteger GainType; 
 
-    typedef int64_t AutoTargetBrightnessValueType;
     typedef Basler_UniversalCameraParams::ShutterModeEnums ShutterModeEnums;
     typedef Basler_UniversalCameraParams::UserOutputSelectorEnums UserOutputSelectorEnums;
     typedef Basler_UniversalCameraParams::LineSelectorEnums LineSelectorEnums;
@@ -84,11 +83,6 @@ struct GigECameraTrait
     typedef Basler_UniversalCameraParams::BalanceRatioSelectorEnums BalanceRatioSelectorEnums;
     typedef Basler_UniversalCameraParams::TimerSelectorEnums TimerSelectorEnums;
     typedef Basler_UniversalCameraParams::TimerTriggerSourceEnums TimerTriggerSourceEnums;
-
-    static inline AutoTargetBrightnessValueType convertBrightness(const int& value)
-    {
-        return value;
-    }
 };
 
 typedef PylonROS2CameraImpl<GigECameraTrait> PylonROS2GigECamera;

--- a/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_usb.hpp
+++ b/pylon_ros2_camera_component/include/internal/impl/pylon_ros2_camera_usb.hpp
@@ -52,7 +52,6 @@ struct USBCameraTrait
     typedef Basler_UniversalCameraParams::PixelSizeEnums PixelSizeEnums;
     typedef GenApi::IFloat AutoTargetBrightnessType;
     typedef GenApi::IFloat GainType;
-    typedef double AutoTargetBrightnessValueType;
     typedef Basler_UniversalCameraParams::ShutterModeEnums ShutterModeEnums;
     typedef Basler_UniversalCameraParams::UserOutputSelectorEnums UserOutputSelectorEnums;
     typedef Basler_UniversalCameraParams::AcquisitionStatusSelectorEnums AcquisitionStatusSelectorEnums;
@@ -76,11 +75,6 @@ struct USBCameraTrait
     typedef Basler_UniversalCameraParams::BalanceRatioSelectorEnums BalanceRatioSelectorEnums;
     typedef Basler_UniversalCameraParams::TimerSelectorEnums TimerSelectorEnums;
     typedef Basler_UniversalCameraParams::TimerTriggerSourceEnums TimerTriggerSourceEnums;
-
-    static inline AutoTargetBrightnessValueType convertBrightness(const int& value)
-    {
-        return value / 255.0;
-    }
 };
 
 typedef PylonROS2CameraImpl<USBCameraTrait> PylonROS2USBCamera;

--- a/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
+++ b/pylon_ros2_camera_component/include/internal/pylon_ros2_camera_impl.hpp
@@ -466,6 +466,12 @@ protected:
     virtual bool setExtendedBrightness(const int& target_brightness,
                                        const float& current_brightness) override;
 
+    // Converts a target brightness (0-255) into the value expected by the camera's
+    // auto brightness node at runtime: the AutoTargetValue node (GigE ace 1) takes the
+    // absolute pixel intensity (0-255), while the AutoTargetBrightness node (USB, GigE ace 2)
+    // takes a normalized brightness (0.0-1.0).
+    double convertBrightness(const int& value);
+
     virtual bool grab(Pylon::CBaslerUniversalGrabResultPtr& grab_result);
 
     virtual bool setupSequencer(const std::vector<float>& exposure_times,


### PR DESCRIPTION
Determine units and conventions for brightness parameter from the availability of AutoTargetValue vs AutoTargetBrightness